### PR TITLE
skip ocpapi integration tests in default test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Test core with pytest
         run: |
-          pytest tests -vv --cov-report=xml --cov=fairchem -c ./packages/fairchem-core/pyproject.toml
+          pytest tests -vv --skip-ocpapi-integration --cov-report=xml --cov=fairchem -c ./packages/fairchem-core/pyproject.toml
 
       - if: ${{ matrix.python_version == '3.11' }}
         name: codecov-report

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+# conftest.py
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--skip-ocpapi-integration", action="store_true", default=False, help="skip ocpapi integration tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "ocpapi_integration: ocpapi integration test")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--skip-ocpapi-integration"):
+        skip_ocpapi_integration = pytest.mark.skip(reason="skipping ocpapi integration")
+        for item in items:
+            if "ocpapi_integration_test" in item.keywords:
+                item.add_marker(skip_ocpapi_integration)
+        return

--- a/tests/demo/ocpapi/tests/integration/client/test_client.py
+++ b/tests/demo/ocpapi/tests/integration/client/test_client.py
@@ -166,6 +166,7 @@ class TestClient(IsolatedAsyncioTestCase):
 
         self.assertGreater(len(response.adsorbate_configs), 10)
 
+    @pytest.mark.ocpapi_integration_test
     async def test_submit_adsorbate_slab_relaxations__gemnet_oc(self) -> None:
         # Make sure that a relaxation can be started for an adsorbate
         # placement on a slab with the gemnet oc model
@@ -257,6 +258,7 @@ class TestClient(IsolatedAsyncioTestCase):
             self.assertNotEqual(response.system_id, "")
             self.assertEqual(len(response.config_ids), 1)
 
+    @pytest.mark.ocpapi_integration_test
     async def test_submit_adsorbate_slab_relaxations__equiformer_v2(self) -> None:
         # Make sure that a relaxation can be started for an adsorbate
         # placement on a slab with the equiformer v2 model
@@ -348,6 +350,7 @@ class TestClient(IsolatedAsyncioTestCase):
             self.assertNotEqual(response.system_id, "")
             self.assertEqual(len(response.config_ids), 1)
 
+    @pytest.mark.ocpapi_integration_test
     async def test_get_adsorbate_slab_relaxations_request(self) -> None:
         # Make sure the original request can be fetched for an already-
         # submitted system.
@@ -360,6 +363,7 @@ class TestClient(IsolatedAsyncioTestCase):
         # of the expected fields was returned
         self.assertEqual(response.adsorbate, "*CO")
 
+    @pytest.mark.ocpapi_integration_test
     async def test_get_adsorbate_slab_relaxations_results__all_fields_and_configs(
         self,
     ) -> None:
@@ -386,6 +390,7 @@ class TestClient(IsolatedAsyncioTestCase):
         config_ids = {c.config_id for c in response.configs}
         self.assertEqual(config_ids, set(range(59)))
 
+    @pytest.mark.ocpapi_integration_test
     async def test_get_adsorbate_slab_relaxations_results__limited_fields_and_configs(
         self,
     ) -> None:


### PR DESCRIPTION
Added an option to pytest, 
--skip-ocpapi-integration
When it is present then ocpapi integration tests that hit the rate limiting API are skipped

if pytest is run without this flag , all tests available are run