### PR TITLE
fixing summary fig and dissociation scheme fig in the gitbook

### DIFF
--- a/docs/tutorials/cattsunami_walkthrough.md
+++ b/docs/tutorials/cattsunami_walkthrough.md
@@ -113,10 +113,7 @@ for config in product2_configs:
 
 ## Enumerate NEBs
 Here we use the class we created to handle automatic generation of NEB frames to create frames using the structures we just relaxed as input.
-
-```{code-cell} ipython3
-Image(filename="dissociation_scheme.png")
-```
+![dissociation_scheme](https://github.com/FAIR-Chem/fairchem/blob/main/src/fairchem/applications/cattsunami/tutorial/dissociation_scheme.png)
 
 ```{code-cell} ipython3
 af = AutoFrameDissociation(

--- a/src/fairchem/applications/cattsunami/README.md
+++ b/src/fairchem/applications/cattsunami/README.md
@@ -7,9 +7,17 @@ CatTSunami is a framework for high-throughput enumeration of nudged elastic band
 This repository contains the validation dataset, framework for enumeration, and accompanying code to run ML-accelerated NEBs and validate new models. For more information, please read the manuscript [paper](https://arxiv.org/abs/2405.02078).
 
 ### Getting started
-Configured for local development
-1. Clone the [`fairchem repo`](https://github.com/FAIR-Chem/fairchem/tree/main) 
-2. Install `fairchem-data-oc` and `fairchem-core`:  [`instructions`](https://fair-chem.github.io/core/install.html)
+Configured for use:
+1. Install fairchem-core and fairchem-data-oc [instructions](https://fair-chem.github.io/core/install.html)
+2. Pip innstall fairchem-applications-cattsunami 
+3. Check out the [tutorial notebook](https://github.com/FAIR-Chem/fairchem/tree/main/src/fairchem/applications/cattsunami/tutorial/workbook.ipynb)
+```
+pip install fairchem-applications-cattsunami
+```
+
+Configured for local development:
+1. Clone the [fairchem repo](https://github.com/FAIR-Chem/fairchem/tree/main) 
+2. Install `fairchem-data-oc` and `fairchem-core`:  [instructions](https://fair-chem.github.io/core/install.html)
 3. Install this repository `pip install -e packages/fairchem-applications-cattsunami`
 4. Check out the [tutorial notebook](https://github.com/FAIR-Chem/fairchem/tree/main/src/fairchem/applications/cattsunami/tutorial/workbook.ipynb)
 

--- a/src/fairchem/applications/cattsunami/README.md
+++ b/src/fairchem/applications/cattsunami/README.md
@@ -1,6 +1,6 @@
 ## CatTSunami: Accelerating Transition State Energy Calculations with Pre-trained Graph Neural Networks
 
-![summary](https://github.com/Open-Catalyst-Project/CatTSunami/blob/master/summary_fig.png)
+![summary](https://github.com/FAIR-Chem/fairchem/blob/main/src/fairchem/applications/cattsunami/summary_fig.png)
 
 CatTSunami is a framework for high-throughput enumeration of nudged elastic band (NEB) frame sets. It was built for use with machine learned (ML) models trained on [OC20](https://arxiv.org/abs/2010.09990), which were demonstrated to be performant on this auxiliary task. To train your own model or obtain pre-trained checkpoints, please see [`fairchem-core`](https://github.com/FAIR-Chem/fairchem/tree/cattsunami-package/src/fairchem/core).
 
@@ -15,7 +15,7 @@ Configured for local development
 
 
 ### Validation Dataset
-The validation dataset is comprised of 932 DFT NEB calculations to assess model performance on this important task. There are 3 different reaction classes considered: desorptions, dissociations, and transfers. For more information see the [dataset markdown file](https://github.com/Open-Catalyst-Project/CatTSunami/blob/master/DATASET.md).
+The validation dataset is comprised of 932 DFT NEB calculations to assess model performance on this important task. There are 3 different reaction classes considered: desorptions, dissociations, and transfers. For more information see the [dataset markdown file](https://github.com/FAIR-Chem/fairchem/blob/main/src/fairchem/applications/cattsunami/DATASET.md).
 
 |Splits |Size of compressed version (in bytes)  |Size of uncompressed version (in bytes)    | MD5 checksum (download link)   |
 |---    |---    |---    |---    |


### PR DESCRIPTION
The summary fig was linked to the old repo and the dissociation scheme image never got copied over. This PR fixes these two things.