### PR TITLE
update preprocess script

### DIFF
--- a/src/fairchem/core/scripts/preprocess_ef.py
+++ b/src/fairchem/core/scripts/preprocess_ef.py
@@ -54,7 +54,7 @@ def write_images_to_lmdb(mp_arg):
             # subtract off reference energy
             if args.ref_energy and not args.test_data:
                 ref_energy = float(frame_log[2])
-                data_object.y -= ref_energy
+                data_object.energy -= ref_energy
 
             txn = db.begin(write=True)
             txn.put(


### PR DESCRIPTION
Resolves https://discuss.opencatalystproject.org/t/error-in-converting-to-lmdb-format-for-s2ef-dataset/474.

Our preprocessing code no longer saves energy as `y`: https://github.com/FAIR-Chem/fairchem/blob/1b4b62b4b71dfe755c94c60839f5d810e5d14a91/src/fairchem/core/preprocessing/atoms_to_graphs.py#L197-L199