### PR TITLE
Add option to launch distributed runs locally with >1 GPU

### DIFF
--- a/src/fairchem/core/_cli.py
+++ b/src/fairchem/core/_cli.py
@@ -51,8 +51,8 @@ class Runner(Checkpointable):
         return DelayedSubmission(new_runner, self.config)
 
 
-def runner_wrapper(config):
-    Runner(distributed=True)(config)
+def runner_wrapper(distributed: bool, config: dict):
+    Runner(distributed=distributed)(config)
 
 
 def main():
@@ -100,12 +100,12 @@ def main():
                 config['optim']['num_workers'] = 0
                 logging.info("WARNING: running in local mode, setting dataloading num_workers to 0, see https://github.com/pytorch/examples/issues/526")
 
-            launch_config = LaunchConfig(min_nodes=1, max_nodes=1, nproc_per_node=args.num_gpus, rdzv_backend="c10d")
-            elastic_launch(launch_config, runner_wrapper)(config)
+            launch_config = LaunchConfig(min_nodes=1, max_nodes=1, nproc_per_node=args.num_gpus, rdzv_backend="c10d", max_restarts=0)
+            elastic_launch(launch_config, runner_wrapper)(args.distributed, config)
         else:
             logging.info("Running in non-distributed local mode")
             assert args.num_gpus == 1, "Can only run with a single gpu in non distributed local mode, use --distributed flag instead if using >1 gpu"
-            Runner(distributed=False)(config)
+            runner_wrapper(args.distributed, config)
 
 if __name__ == '__main__':
     main()

--- a/src/fairchem/core/_cli.py
+++ b/src/fairchem/core/_cli.py
@@ -11,9 +11,9 @@ import copy
 import logging
 from typing import TYPE_CHECKING
 
-from torch.distributed.launcher.api import elastic_launch, LaunchConfig
 from submitit import AutoExecutor
 from submitit.helpers import Checkpointable, DelayedSubmission
+from torch.distributed.launcher.api import LaunchConfig, elastic_launch
 
 from fairchem.core.common.flags import flags
 from fairchem.core.common.utils import (
@@ -96,8 +96,8 @@ def main():
             # HACK to disable multiprocess dataloading in local mode
             # there is an open issue where LMDB's environment cannot be pickled and used
             # during torch multiprocessing https://github.com/pytorch/examples/issues/526
-            if 'optim' in config and 'num_workers' in config['optim']:
-                config['optim']['num_workers'] = 0
+            if "optim" in config and "num_workers" in config["optim"]:
+                config["optim"]["num_workers"] = 0
                 logging.info("WARNING: running in local mode, setting dataloading num_workers to 0, see https://github.com/pytorch/examples/issues/526")
 
             launch_config = LaunchConfig(min_nodes=1, max_nodes=1, nproc_per_node=args.num_gpus, rdzv_backend="c10d", max_restarts=0)
@@ -107,5 +107,5 @@ def main():
             assert args.num_gpus == 1, "Can only run with a single gpu in non distributed local mode, use --distributed flag instead if using >1 gpu"
             runner_wrapper(args.distributed, config)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/fairchem/core/common/distutils.py
+++ b/src/fairchem/core/common/distutils.py
@@ -97,13 +97,8 @@ def setup(config) -> None:
             init_method="env://",
         )
     else:
-        # try to read local rank from environment for newer torchrun
-        # otherwise use local-rank arg for torch.distributed
-        config["local_rank"] = os.environ.get("LOCAL_RANK", config["local_rank"])
-        dist.init_process_group(
-            backend=config["distributed_backend"], init_method="env://"
-        )
-    # TODO: SLURM
+        config["local_rank"] = int(os.environ.get("LOCAL_RANK", config["local_rank"]))
+        dist.init_process_group(backend="nccl")
 
 
 def cleanup() -> None:

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -3,15 +3,14 @@ import sys
 
 from fairchem.core._cli import main
 
-def fake_runner_distributed(distributed: bool, config: dict):
-    assert distributed
+def fake_runner(distributed: bool, config: dict):
+    assert not distributed
     assert config["local_rank"] == 0
     assert config["world_size"] == 1
 
-def test_cli_distributed():
-    with patch('fairchem.core._cli.runner_wrapper',fake_runner_distributed):
+def test_cli():
+    with patch('fairchem.core._cli.runner_wrapper',fake_runner):
         sys_args = ['--debug', 
-                    '--distributed', 
                     '--mode', 
                     'train', 
                     '--identifier', 

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1,7 +1,10 @@
-from unittest.mock import patch
+from __future__ import annotations
+
 import sys
+from unittest.mock import patch
 
 from fairchem.core._cli import main
+
 
 def fake_runner(distributed: bool, config: dict):
     assert not distributed
@@ -9,13 +12,27 @@ def fake_runner(distributed: bool, config: dict):
     assert config["world_size"] == 1
 
 def test_cli():
-    with patch('fairchem.core._cli.runner_wrapper',fake_runner):
-        sys_args = ['--debug', 
-                    '--mode', 
-                    'train', 
-                    '--identifier', 
-                    'test', 
-                    '--config-yml', 
-                    'configs/oc22/s2ef/equiformer_v2/equiformer_v2_N@18_L@6_M@2_e4_f100_121M.yml']
+    with patch("fairchem.core._cli.runner_wrapper",fake_runner):
+        sys_args = ["--debug",
+                    "--mode",
+                    "train",
+                    "--identifier",
+                    "test",
+                    "--config-yml",
+                    "configs/oc22/s2ef/equiformer_v2/equiformer_v2_N@18_L@6_M@2_e4_f100_121M.yml"]
         sys.argv[1:] = sys_args
         main()
+
+def test_cli_distributed():
+    with patch("fairchem.core._cli.elastic_launch") as mock_elastic_launch:
+        sys_args = ["--debug",
+                    "--distributed",
+                    "--mode",
+                    "train",
+                    "--identifier",
+                    "test",
+                    "--config-yml",
+                    "configs/oc22/s2ef/equiformer_v2/equiformer_v2_N@18_L@6_M@2_e4_f100_121M.yml"]
+        sys.argv[1:] = sys_args
+        main()
+        mock_elastic_launch.assert_called_once()

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1,0 +1,23 @@
+from unittest.mock import MagicMock, patch
+import pytest
+import sys
+
+from fairchem.core._cli import main
+
+def fake_runner_distributed(distributed: bool, config: dict):
+    assert distributed == True
+    assert config["local_rank"] == 0
+    assert config["world_size"] == 1
+
+def test_cli_distributed():
+    with patch('fairchem.core._cli.runner_wrapper',fake_runner_distributed):
+        sys_args = ['--debug', 
+                    '--distributed', 
+                    '--mode', 
+                    'train', 
+                    '--identifier', 
+                    'test', 
+                    '--config-yml', 
+                    'configs/oc22/s2ef/equiformer_v2/equiformer_v2_N@18_L@6_M@2_e4_f100_121M.yml']
+        sys.argv[1:] = sys_args
+        main()

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1,11 +1,10 @@
-from unittest.mock import MagicMock, patch
-import pytest
+from unittest.mock import patch
 import sys
 
 from fairchem.core._cli import main
 
 def fake_runner_distributed(distributed: bool, config: dict):
-    assert distributed == True
+    assert distributed
     assert config["local_rank"] == 0
     assert config["world_size"] == 1
 


### PR DESCRIPTION
Add option to launch distributed runs locally with >1 GPU. Useful for testing parallel algorithms locally. This uses torch elastic API which just spawns python multiprocesses under the hood.

This is equivalent to calling our application with [torchrun](https://pytorch.org/docs/stable/elastic/run.html ) ie: `torchrun fairchem ...`, but makes the interface cleaner so we dont need to work with 2 launchers
Note: torchrun just calls the [elastic launch API](https://github.com/pytorch/pytorch/blob/main/torch/distributed/launcher/api.py#L30) under the hood

There's a bug where LMBDs cannot be pickled (needed for multiprocessing), this is resolvable by setting num_workers to 0 which is ok for local mode testing.

examples:
To run locally on 2 GPUs with distributed:
```fairchem --debug --mode train --identifier gp_test --config-yml src/fairchem/experimental/rgao/configs/equiformer_v2_N\@8_L\@4_M\@2_31M.yml --amp --distributed --num-gpus=2```

To run locally without distributed:
```fairchem --debug --mode train --identifier gp_test --config-yml src/fairchem/experimental/rgao/configs/equiformer_v2_N\@8_L\@4_M\@2_31M.yml --amp```

Testing:

Add simple test for test_cli.py for now which mocks the runner, should add tests later for actual simple runs