### PR TITLE
pin ruff to 0.4.10

### DIFF
--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]  # add optional dependencies to be installed as pip install fairchem.core[dev]
-dev = ["pre-commit", "pytest", "pytest-cov", "coverage", "syrupy", "ruff"]
+dev = ["pre-commit", "pytest", "pytest-cov", "coverage", "syrupy", "ruff==0.4.10"]
 docs = ["jupyter-book", "jupytext", "sphinx","sphinx-autoapi", "umap-learn", "vdict"]
 adsorbml = ["dscribe","x3dase","scikit-image"]
 


### PR DESCRIPTION
Ruff was unpinned and upgraded to 0.5, which started triggering lint issues
<img width="529" alt="image" src="https://github.com/FAIR-Chem/fairchem/assets/7001989/8f728c90-5275-4a91-94e9-2179237c6066">
