### PR TITLE
Hide wandb.watch behind flag

### DIFF
--- a/src/fairchem/core/common/logger.py
+++ b/src/fairchem/core/common/logger.py
@@ -27,7 +27,7 @@ class Logger(ABC):
         self.config = config
 
     @abstractmethod
-    def watch(self, model):
+    def watch(self, model, log_freq: int = 1000):
         """
         Monitor parameters and gradients.
         """
@@ -82,8 +82,8 @@ class WandBLogger(Logger):
             resume="allow",
         )
 
-    def watch(self, model) -> None:
-        wandb.watch(model)
+    def watch(self, model, log_freq: int = 1000) -> None:
+        wandb.watch(model, log_freq = log_freq)
 
     def log(self, update_dict, step: int, split: str = "") -> None:
         update_dict = super().log(update_dict, step, split)
@@ -109,7 +109,7 @@ class TensorboardLogger(Logger):
         self.writer = SummaryWriter(self.config["cmd"]["logs_dir"])
 
     # TODO: add a model hook for watching gradients.
-    def watch(self, model) -> bool:
+    def watch(self, model, log_freq: int = 1000) -> bool:
         logging.warning("Model gradient logging to tensorboard not yet supported.")
         return False
 

--- a/src/fairchem/core/trainers/base_trainer.py
+++ b/src/fairchem/core/trainers/base_trainer.py
@@ -429,7 +429,11 @@ class BaseTrainer(ABC):
             )
 
         if self.logger is not None:
-            self.logger.watch(self.model)
+            # only "watch" model if user specify watch: True because logging gradients
+            # spews too much data into W&B and makes the UI slow to respond
+            import pdb;pdb.set_trace()
+            if self.config["logger"].get("watch", False):
+                self.logger.watch(self.model)
             self.logger.log_summary({"num_params": self.model.num_params})
 
         if distutils.initialized() and not self.config["noddp"]:

--- a/src/fairchem/core/trainers/base_trainer.py
+++ b/src/fairchem/core/trainers/base_trainer.py
@@ -431,9 +431,8 @@ class BaseTrainer(ABC):
         if self.logger is not None:
             # only "watch" model if user specify watch: True because logging gradients
             # spews too much data into W&B and makes the UI slow to respond
-            import pdb;pdb.set_trace()
-            if self.config["logger"].get("watch", False):
-                self.logger.watch(self.model)
+            if "watch" in self.config["logger"]:
+                self.logger.watch(self.model, log_freq = int(self.config["logger"]["watch"]))
             self.logger.log_summary({"num_params": self.model.num_params})
 
         if distutils.initialized() and not self.config["noddp"]:


### PR DESCRIPTION
[wanbd.watch](https://docs.wandb.ai/ref/python/watch) logs too much data and makes the UI slow, turn it off by default.

Example usage (config in yaml):
```
logger:
  name: wandb
  entity: fairchem
  project: fm_testing
  watch: 1000
```
the number specifies the frequency (in # of steps) to log gradients etc..

Run without watch: https://fairwandb.org/fairchem/fm_testing/runs/2024-07-02-16-12-48-local_test_no_watch
Run with watch: https://fairwandb.org/fairchem/fm_testing/runs/2024-07-02-16-10-40-local_test_watch