### PR TITLE
Add slurm qos setting

### DIFF
--- a/src/fairchem/core/_cli.py
+++ b/src/fairchem/core/_cli.py
@@ -81,6 +81,8 @@ def main():
             tasks_per_node=(args.num_gpus if args.distributed else 1),
             nodes=args.num_nodes,
             slurm_additional_parameters=slurm_add_params,
+            slurm_qos=args.slurm_qos,
+            slurm_account=args.slurm_account,
         )
         for config in configs:
             config["slurm"] = copy.deepcopy(executor.parameters)

--- a/src/fairchem/core/common/flags.py
+++ b/src/fairchem/core/common/flags.py
@@ -92,9 +92,21 @@ class Flags:
         )
         self.parser.add_argument(
             "--slurm-partition",
-            default="ocp",
+            default="learn",
             type=str,
             help="Name of partition",
+        )
+        self.parser.add_argument(
+            "--slurm-account",
+            default="ocp",
+            type=str,
+            help="Name of account",
+        )
+        self.parser.add_argument(
+            "--slurm-qos",
+            default="ocp_high",
+            type=str,
+            help="Name of qos",
         )
         self.parser.add_argument(
             "--slurm-mem", default=80, type=int, help="Memory (in gigabytes)"

--- a/src/fairchem/core/common/flags.py
+++ b/src/fairchem/core/common/flags.py
@@ -92,19 +92,19 @@ class Flags:
         )
         self.parser.add_argument(
             "--slurm-partition",
-            default="learn",
+            default=None,
             type=str,
             help="Name of partition",
         )
         self.parser.add_argument(
             "--slurm-account",
-            default="ocp",
+            default=None,
             type=str,
             help="Name of account",
         )
         self.parser.add_argument(
             "--slurm-qos",
-            default="ocp_high",
+            default=None,
             type=str,
             help="Name of qos",
         )


### PR DESCRIPTION
FAIRCluster uses partitions while AWS uses slurm-account and slurm-qos (https://docs.google.com/document/d/19AJC5sL17t4f2zzn6ylW6-mO0CGeONs8ogKprMrWNxA/edit#heading=h.lbn5dlaajt5m)

For FAIRCluster use: 
slurm-partition: {ocp, learnfair, etc..}

For AWS:
slurm-partition: learn
slurm-account: ocp
slurm-qos: {ocp_high, lowest}
