### PR TITLE
Remove detaches to enable gradient-based force EquiformerV2 models.

### DIFF
--- a/src/fairchem/core/models/equiformer_v2/edge_rot_mat.py
+++ b/src/fairchem/core/models/equiformer_v2/edge_rot_mat.py
@@ -45,7 +45,7 @@ def init_edge_rot_mat(edge_distance_vec):
     norm_y = norm_y / (torch.sqrt(torch.sum(norm_y**2, dim=1, keepdim=True)))
 
     yprod = (norm_x @ norm_x.new_tensor([0,1,0]))
-    
+
     # Construct the 3D rotation matrix
     norm_x = norm_x.view(-1, 3, 1)
     norm_y = -norm_y.view(-1, 3, 1)
@@ -61,5 +61,5 @@ def init_edge_rot_mat(edge_distance_vec):
     output[~mask, 2, :] = edge_rot_mat[~mask, 2, :]
     output[yprod > 0.9999, 1, :] = edge_rot_mat.new_tensor([[0., 1., 0.]])
     output[yprod < -0.9999, 1, :] = edge_rot_mat.new_tensor([[0., -1., 0.]])
-    
+
     return output

--- a/src/fairchem/core/models/equiformer_v2/so3.py
+++ b/src/fairchem/core/models/equiformer_v2/so3.py
@@ -453,8 +453,6 @@ class SO3_Rotation(torch.nn.Module):
         self.device, self.dtype = rot_mat3x3.device, rot_mat3x3.dtype
         self.wigner = self.RotationToWignerDMatrix(rot_mat3x3, 0, self.lmax)
         self.wigner_inv = torch.transpose(self.wigner, 1, 2).contiguous()
-        self.wigner = self.wigner.detach()
-        self.wigner_inv = self.wigner_inv.detach()
 
     # Rotate the embedding
     def rotate(self, embedding, out_lmax: int, out_mmax: int):
@@ -494,7 +492,7 @@ class SO3_Rotation(torch.nn.Module):
             wigner[:, start:end, start:end] = block
             start = end
 
-        return wigner.detach()
+        return wigner
 
 
 class SO3_Grid(torch.nn.Module):

--- a/src/fairchem/core/models/equiformer_v2/so3.py
+++ b/src/fairchem/core/models/equiformer_v2/so3.py
@@ -476,6 +476,9 @@ class SO3_Rotation(torch.nn.Module):
     ) -> torch.Tensor:
         x = edge_rot_mat @ edge_rot_mat.new_tensor([0.0, 1.0, 0.0])
         alpha, beta = o3.xyz_to_angles(x)
+        yprod = (x @ x.new_tensor([0, 1, 0]))
+        beta[yprod > 0.9999] = 0.
+        beta[yprod < -0.9999] = math.pi
         R = (
             o3.angles_to_matrix(alpha, beta, torch.zeros_like(alpha)).transpose(-1, -2)
             @ edge_rot_mat


### PR DESCRIPTION
Remove the detaches in obtaining rotation matrices and wignerD matrices for correct gradients of model outputs with regard to atomic positions. 

Naively remove the detaches result in instability due to gradient explosion for y-axis rotation of ~0 or ~180 degree. 

In this fix, we instead do not rotate / rotate 180 degree for edges that are already aligned with the y-axis. This fix enables correct gradients of model outputs with regard to the input atom positions and thus enable training energy-conserving gradient-based force EquiformerV2 models.