### PR TITLE
clone so3 embedding object

### DIFF
--- a/src/fairchem/core/models/equiformer_v2/transformer_block.py
+++ b/src/fairchem/core/models/equiformer_v2/transformer_block.py
@@ -652,7 +652,7 @@ class TransBlockV2(torch.nn.Module):
         batch,  # for GraphDropPath
         node_offset: int = 0,
     ):
-        output_embedding = x
+        output_embedding = x.clone()
 
         x_res = output_embedding.embedding
         output_embedding.embedding = self.norm_1(output_embedding.embedding)


### PR DESCRIPTION
1 line change, this is needed for activation checkpointing to work if we want the interface to remain passing SO3_embedding objects to the transformer. In normal operation the code is not wrong but error prone because the function modifies the input inplace, which the user does not expect. See https://fairwandb.org/fairchem/fm_testing/reports/Training-Instability-of-Large-EQV2-Models--Vmlldzo0MzI5NQ for more details

The alternative solution is to change the transformer.forward signature to take tensors instead but this introduces more breaking changes in the code

* introduces tiny memory diffs: https://fairwandb.org/fairchem/fm_testing/reports/Clone-vs-no-clone-input-to-transformer--Vmlldzo0MzQ5Nw