### PR TITLE
fix issues with ddp/hydra and add tests

### DIFF
--- a/src/fairchem/core/models/equiformer_v2/equiformer_v2.py
+++ b/src/fairchem/core/models/equiformer_v2/equiformer_v2.py
@@ -686,6 +686,7 @@ class EquiformerV2(nn.Module, GraphModelMixin):
 class EquiformerV2Backbone(EquiformerV2, BackboneInterface):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # TODO remove these once we deprecate/stop-inheriting EquiformerV2 class
         self.energy_block = None
         self.force_block = None
 

--- a/src/fairchem/core/models/equiformer_v2/equiformer_v2.py
+++ b/src/fairchem/core/models/equiformer_v2/equiformer_v2.py
@@ -61,6 +61,7 @@ class EquiformerV2(nn.Module, GraphModelMixin):
 
     Args:
         use_pbc (bool):         Use periodic boundary conditions
+        use_pbc_single (bool):         Process batch PBC graphs one at a time
         regress_forces (bool):  Compute forces
         otf_graph (bool):       Compute graph On The Fly (OTF)
         max_neighbors (int):    Maximum number of neighbors per atom
@@ -683,6 +684,11 @@ class EquiformerV2(nn.Module, GraphModelMixin):
 
 @registry.register_model("equiformer_v2_backbone")
 class EquiformerV2Backbone(EquiformerV2, BackboneInterface):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.energy_block = None
+        self.force_block = None
+
     @conditional_grad(torch.enable_grad())
     def forward(self, data: Batch) -> dict[str, torch.Tensor]:
         self.batch_size = len(data.natoms)
@@ -815,6 +821,7 @@ class EquiformerV2Backbone(EquiformerV2, BackboneInterface):
 class EquiformerV2EnergyHead(nn.Module, HeadInterface):
     def __init__(self, backbone):
         super().__init__()
+
         self.avg_num_nodes = backbone.avg_num_nodes
         self.energy_block = FeedForwardNetwork(
             backbone.sphere_channels,
@@ -828,6 +835,8 @@ class EquiformerV2EnergyHead(nn.Module, HeadInterface):
             backbone.use_grid_mlp,
             backbone.use_sep_s2_act,
         )
+        self.apply(backbone._init_weights)
+        self.apply(backbone._uniform_init_rad_func_linear_weights)
 
     def forward(self, data: Batch, emb: dict[str, torch.Tensor | GraphData]):
         node_energy = self.energy_block(emb["node_embedding"])
@@ -871,6 +880,8 @@ class EquiformerV2ForceHead(nn.Module, HeadInterface):
             backbone.use_sep_s2_act,
             alpha_drop=0.0,
         )
+        self.apply(backbone._init_weights)
+        self.apply(backbone._uniform_init_rad_func_linear_weights)
 
     def forward(self, data: Batch, emb: dict[str, torch.Tensor]):
         forces = self.force_block(

--- a/src/fairchem/core/models/escn/escn.py
+++ b/src/fairchem/core/models/escn/escn.py
@@ -530,7 +530,7 @@ class eSCNBackbone(eSCN, BackboneInterface):
 class eSCNEnergyHead(nn.Module, HeadInterface):
     def __init__(self, backbone):
         super().__init__()
-
+        backbone.energy_block = None
         # Output blocks for energy and forces
         self.energy_block = EnergyBlock(
             backbone.sphere_channels_all, backbone.num_sphere_samples, backbone.act
@@ -550,7 +550,7 @@ class eSCNEnergyHead(nn.Module, HeadInterface):
 class eSCNForceHead(nn.Module, HeadInterface):
     def __init__(self, backbone):
         super().__init__()
-
+        backbone.force_block = None
         self.force_block = ForceBlock(
             backbone.sphere_channels_all, backbone.num_sphere_samples, backbone.act
         )

--- a/src/fairchem/core/models/gemnet_oc/gemnet_oc.py
+++ b/src/fairchem/core/models/gemnet_oc/gemnet_oc.py
@@ -1431,6 +1431,9 @@ class GemNetOCEnergyAndGradForceHead(nn.Module, HeadInterface):
         self.direct_forces = backbone.direct_forces
         self.force_scaler = backbone.force_scaler
 
+        backbone.out_mlp_E = None
+        backbone.out_energy = None
+
         out_mlp_E = [
             Dense(
                 backbone.atom_emb.emb_size * (len(backbone.int_blocks) + 1),
@@ -1495,6 +1498,8 @@ class GemNetOCForceHead(nn.Module, HeadInterface):
 
         emb_size_edge = backbone.edge_emb.dense.linear.out_features
         if self.direct_forces:
+            backbone.out_mlp_F = None
+            backbone.out_forces = None
             out_mlp_F = [
                 Dense(
                     emb_size_edge * (len(backbone.int_blocks) + 1),

--- a/src/fairchem/core/models/painn/painn.py
+++ b/src/fairchem/core/models/painn/painn.py
@@ -671,7 +671,7 @@ class GatedEquivariantBlock(nn.Module):
 class PaiNNEnergyHead(nn.Module, HeadInterface):
     def __init__(self, backbone):
         super().__init__()
-
+        backbone.out_energy = None
         self.out_energy = nn.Sequential(
             nn.Linear(backbone.hidden_channels, backbone.hidden_channels // 2),
             ScaledSiLU(),
@@ -697,6 +697,7 @@ class PaiNNForceHead(nn.Module, HeadInterface):
         self.direct_forces = backbone.direct_forces
 
         if self.direct_forces:
+            backbone.out_forces = None
             self.out_forces = PaiNNOutput(backbone.hidden_channels)
 
     def forward(

--- a/tests/core/models/test_configs/test_dpp.yml
+++ b/tests/core/models/test_configs/test_dpp.yml
@@ -1,19 +1,38 @@
 trainer: forces
 
-task:
-  dataset: lmdb
-  type: regression
-  metric: mae
-  primary_metric: forces_mae
-  labels:
-    - potential energy
-  grad_input: atomic forces
-  train_on_free_atoms: True
-  eval_on_free_atoms: True
-  prediction_dtype: float32
+outputs:
+  energy:
+    shape: 1
+    level: system
+  forces:
+    irrep_dim: 1
+    level: atom
+    train_on_free_atoms: True
+    eval_on_free_atoms: True
 
+loss_functions:
+  - energy:
+      fn: mae
+      coefficient: 2
+  - forces:
+      fn: l2mae
+      coefficient: 100
+
+evaluation_metrics:
+  metrics:
+    energy:
+      - mae
+    forces:
+      - mae
+      - cosine_similarity
+      - magnitude_error
+    misc:
+      - energy_forces_within_threshold
+  primary_metric: forces_mae
+  
 logger:
     name: tensorboard
+
 
 model:
   name: dimenetplusplus #_bbwheads

--- a/tests/core/models/test_configs/test_dpp_hydra.yml
+++ b/tests/core/models/test_configs/test_dpp_hydra.yml
@@ -1,19 +1,38 @@
 trainer: forces
 
-task:
-  dataset: lmdb
-  type: regression
-  metric: mae
-  primary_metric: forces_mae
-  labels:
-    - potential energy
-  grad_input: atomic forces
-  train_on_free_atoms: True
-  eval_on_free_atoms: True
-  prediction_dtype: float32
+outputs:
+  energy:
+    shape: 1
+    level: system
+  forces:
+    irrep_dim: 1
+    level: atom
+    train_on_free_atoms: True
+    eval_on_free_atoms: True
 
+loss_functions:
+  - energy:
+      fn: mae
+      coefficient: 2
+  - forces:
+      fn: l2mae
+      coefficient: 100
+
+evaluation_metrics:
+  metrics:
+    energy:
+      - mae
+    forces:
+      - mae
+      - cosine_similarity
+      - magnitude_error
+    misc:
+      - energy_forces_within_threshold
+  primary_metric: forces_mae
+  
 logger:
     name: tensorboard
+
 
 model:
   name: hydra

--- a/tests/core/models/test_configs/test_equiformerv2_hydra.yml
+++ b/tests/core/models/test_configs/test_equiformerv2_hydra.yml
@@ -1,6 +1,37 @@
-
-
 trainer: forces
+
+outputs:
+  energy:
+    shape: 1
+    level: system
+  forces:
+    irrep_dim: 1
+    level: atom
+    train_on_free_atoms: True
+    eval_on_free_atoms: True
+
+loss_functions:
+  - energy:
+      fn: mae
+      coefficient: 2
+  - forces:
+      fn: l2mae
+      coefficient: 100
+
+evaluation_metrics:
+  metrics:
+    energy:
+      - mae
+    forces:
+      - mae
+      - cosine_similarity
+      - magnitude_error
+    misc:
+      - energy_forces_within_threshold
+  primary_metric: forces_mae
+  
+logger:
+    name: tensorboard
 
 model:
   name: hydra
@@ -52,34 +83,6 @@ model:
       module: equiformer_v2_energy_head
     forces:
       module: equiformer_v2_force_head
-
-dataset:
-  train:
-    src: tutorial_dset/s2ef/train_100/
-    normalize_labels: True
-    target_mean: -0.7554450631141663
-    target_std: 2.887317180633545
-    grad_target_mean: 0.0
-    grad_target_std: 2.887317180633545
-  val:
-    format: lmdb
-    src: tutorial_dset/s2ef/val_20/
-
-logger:
-  name: tensorboard
-
-task:
-  dataset: lmdb
-  type: regression
-  metric: mae
-  primary_metric: forces_mae
-  labels:
-    - potential energy
-  grad_input: atomic forces
-  train_on_free_atoms: True
-  eval_on_free_atoms: True
-  prediction_dtype: float32
-
 
 optim:
   batch_size: 5

--- a/tests/core/models/test_configs/test_escn_hydra.yml
+++ b/tests/core/models/test_configs/test_escn_hydra.yml
@@ -1,31 +1,38 @@
 trainer: forces
 
-dataset:
-  train:
-    src: tutorial_dset/s2ef/train_100/
-    normalize_labels: True
-    target_mean: -0.7554450631141663
-    target_std: 2.887317180633545
-    grad_target_mean: 0.0
-    grad_target_std: 2.887317180633545
-  val:
-    format: lmdb
-    src: tutorial_dset/s2ef/val_20/
+outputs:
+  energy:
+    shape: 1
+    level: system
+  forces:
+    irrep_dim: 1
+    level: atom
+    train_on_free_atoms: True
+    eval_on_free_atoms: True
 
-logger:
-  name: tensorboard
+loss_functions:
+  - energy:
+      fn: mae
+      coefficient: 2
+  - forces:
+      fn: l2mae
+      coefficient: 100
 
-task:
-  dataset: lmdb
-  type: regression
-  metric: mae
+evaluation_metrics:
+  metrics:
+    energy:
+      - mae
+    forces:
+      - mae
+      - cosine_similarity
+      - magnitude_error
+    misc:
+      - energy_forces_within_threshold
   primary_metric: forces_mae
-  labels:
-    - potential energy
-  grad_input: atomic forces
-  train_on_free_atoms: True
-  eval_on_free_atoms: True
-  prediction_dtype: float32
+  
+logger:
+    name: tensorboard
+
 
 model:
   name: hydra

--- a/tests/core/models/test_configs/test_gemnet_dt_hydra.yml
+++ b/tests/core/models/test_configs/test_gemnet_dt_hydra.yml
@@ -1,31 +1,37 @@
 trainer: forces
 
-dataset:
-  train:
-    src: tutorial_dset/s2ef/train_100/
-    normalize_labels: True
-    target_mean: -0.7554450631141663
-    target_std: 2.887317180633545
-    grad_target_mean: 0.0
-    grad_target_std: 2.887317180633545
-  val:
-    format: lmdb
-    src: tutorial_dset/s2ef/val_20/
+outputs:
+  energy:
+    shape: 1
+    level: system
+  forces:
+    irrep_dim: 1
+    level: atom
+    train_on_free_atoms: True
+    eval_on_free_atoms: True
 
-logger:
-  name: tensorboard
+loss_functions:
+  - energy:
+      fn: mae
+      coefficient: 2
+  - forces:
+      fn: l2mae
+      coefficient: 100
 
-task:
-  dataset: lmdb
-  type: regression
-  metric: mae
+evaluation_metrics:
+  metrics:
+    energy:
+      - mae
+    forces:
+      - mae
+      - cosine_similarity
+      - magnitude_error
+    misc:
+      - energy_forces_within_threshold
   primary_metric: forces_mae
-  labels:
-    - potential energy
-  grad_input: atomic forces
-  train_on_free_atoms: True
-  eval_on_free_atoms: True
-  prediction_dtype: float32
+  
+logger:
+    name: tensorboard
 
 model:
   name: hydra

--- a/tests/core/models/test_configs/test_gemnet_dt_hydra_grad.yml
+++ b/tests/core/models/test_configs/test_gemnet_dt_hydra_grad.yml
@@ -1,31 +1,38 @@
 trainer: forces
 
-dataset:
-  train:
-    src: tutorial_dset/s2ef/train_100/
-    normalize_labels: True
-    target_mean: -0.7554450631141663
-    target_std: 2.887317180633545
-    grad_target_mean: 0.0
-    grad_target_std: 2.887317180633545
-  val:
-    format: lmdb
-    src: tutorial_dset/s2ef/val_20/
+outputs:
+  energy:
+    shape: 1
+    level: system
+  forces:
+    irrep_dim: 1
+    level: atom
+    train_on_free_atoms: True
+    eval_on_free_atoms: True
 
-logger:
-  name: tensorboard
+loss_functions:
+  - energy:
+      fn: mae
+      coefficient: 2
+  - forces:
+      fn: l2mae
+      coefficient: 100
 
-task:
-  dataset: lmdb
-  type: regression
-  metric: mae
+evaluation_metrics:
+  metrics:
+    energy:
+      - mae
+    forces:
+      - mae
+      - cosine_similarity
+      - magnitude_error
+    misc:
+      - energy_forces_within_threshold
   primary_metric: forces_mae
-  labels:
-    - potential energy
-  grad_input: atomic forces
-  train_on_free_atoms: True
-  eval_on_free_atoms: True
-  prediction_dtype: float32
+  
+logger:
+    name: tensorboard
+
 
 model:
   name: hydra

--- a/tests/core/models/test_configs/test_gemnet_oc_hydra.yml
+++ b/tests/core/models/test_configs/test_gemnet_oc_hydra.yml
@@ -1,34 +1,38 @@
-
-
-
 trainer: forces
 
-dataset:
-  train:
-    src: tutorial_dset/s2ef/train_100/
-    normalize_labels: True
-    target_mean: -0.7554450631141663
-    target_std: 2.887317180633545
-    grad_target_mean: 0.0
-    grad_target_std: 2.887317180633545
-  val:
-    format: lmdb
-    src: tutorial_dset/s2ef/val_20/
+outputs:
+  energy:
+    shape: 1
+    level: system
+  forces:
+    irrep_dim: 1
+    level: atom
+    train_on_free_atoms: True
+    eval_on_free_atoms: True
 
-logger:
-  name: tensorboard
+loss_functions:
+  - energy:
+      fn: mae
+      coefficient: 2
+  - forces:
+      fn: l2mae
+      coefficient: 100
 
-task:
-  dataset: lmdb
-  type: regression
-  metric: mae
+evaluation_metrics:
+  metrics:
+    energy:
+      - mae
+    forces:
+      - mae
+      - cosine_similarity
+      - magnitude_error
+    misc:
+      - energy_forces_within_threshold
   primary_metric: forces_mae
-  labels:
-    - potential energy
-  grad_input: atomic forces
-  train_on_free_atoms: True
-  eval_on_free_atoms: True
-  prediction_dtype: float32
+  
+logger:
+    name: tensorboard
+
 
 model:
   name: hydra

--- a/tests/core/models/test_configs/test_gemnet_oc_hydra_grad.yml
+++ b/tests/core/models/test_configs/test_gemnet_oc_hydra_grad.yml
@@ -1,34 +1,39 @@
 
-
-
 trainer: forces
 
-dataset:
-  train:
-    src: tutorial_dset/s2ef/train_100/
-    normalize_labels: True
-    target_mean: -0.7554450631141663
-    target_std: 2.887317180633545
-    grad_target_mean: 0.0
-    grad_target_std: 2.887317180633545
-  val:
-    format: lmdb
-    src: tutorial_dset/s2ef/val_20/
+outputs:
+  energy:
+    shape: 1
+    level: system
+  forces:
+    irrep_dim: 1
+    level: atom
+    train_on_free_atoms: True
+    eval_on_free_atoms: True
 
-logger:
-  name: tensorboard
+loss_functions:
+  - energy:
+      fn: mae
+      coefficient: 2
+  - forces:
+      fn: l2mae
+      coefficient: 100
 
-task:
-  dataset: lmdb
-  type: regression
-  metric: mae
+evaluation_metrics:
+  metrics:
+    energy:
+      - mae
+    forces:
+      - mae
+      - cosine_similarity
+      - magnitude_error
+    misc:
+      - energy_forces_within_threshold
   primary_metric: forces_mae
-  labels:
-    - potential energy
-  grad_input: atomic forces
-  train_on_free_atoms: True
-  eval_on_free_atoms: True
-  prediction_dtype: float32
+  
+logger:
+    name: tensorboard
+
 
 model:
   name: hydra

--- a/tests/core/models/test_configs/test_painn.yml
+++ b/tests/core/models/test_configs/test_painn.yml
@@ -1,17 +1,35 @@
+
 trainer: forces
 
-task:
-  dataset: lmdb
-  type: regression
-  metric: mae
-  primary_metric: forces_mae
-  labels:
-    - potential energy
-  grad_input: atomic forces
-  train_on_free_atoms: True
-  eval_on_free_atoms: True
-  prediction_dtype: float32
+outputs:
+  energy:
+    shape: 1
+    level: system
+  forces:
+    irrep_dim: 1
+    level: atom
+    train_on_free_atoms: True
+    eval_on_free_atoms: True
 
+loss_functions:
+  - energy:
+      fn: mae
+      coefficient: 2
+  - forces:
+      fn: l2mae
+      coefficient: 100
+
+evaluation_metrics:
+  metrics:
+    energy:
+      - mae
+    forces:
+      - mae
+      - cosine_similarity
+      - magnitude_error
+    misc:
+      - energy_forces_within_threshold
+  primary_metric: forces_mae
 logger:
     name: tensorboard
 
@@ -30,7 +48,6 @@ model:
 optim:
   batch_size: 32
   eval_batch_size: 32
-  load_balancing: atoms
   eval_every: 5000
   num_workers: 2
   optimizer: AdamW

--- a/tests/core/models/test_configs/test_painn_hydra.yml
+++ b/tests/core/models/test_configs/test_painn_hydra.yml
@@ -1,19 +1,38 @@
 trainer: forces
 
-task:
-  dataset: lmdb
-  type: regression
-  metric: mae
-  primary_metric: forces_mae
-  labels:
-    - potential energy
-  grad_input: atomic forces
-  train_on_free_atoms: True
-  eval_on_free_atoms: True
-  prediction_dtype: float32
+outputs:
+  energy:
+    shape: 1
+    level: system
+  forces:
+    irrep_dim: 1
+    level: atom
+    train_on_free_atoms: True
+    eval_on_free_atoms: True
 
+loss_functions:
+  - energy:
+      fn: mae
+      coefficient: 2
+  - forces:
+      fn: l2mae
+      coefficient: 100
+
+evaluation_metrics:
+  metrics:
+    energy:
+      - mae
+    forces:
+      - mae
+      - cosine_similarity
+      - magnitude_error
+    misc:
+      - energy_forces_within_threshold
+  primary_metric: forces_mae
+  
 logger:
     name: tensorboard
+
 
 model:
   name: hydra

--- a/tests/core/models/test_configs/test_painn_hydra.yml
+++ b/tests/core/models/test_configs/test_painn_hydra.yml
@@ -38,7 +38,6 @@ model:
 optim:
   batch_size: 32
   eval_batch_size: 32
-  load_balancing: atoms
   eval_every: 5000
   num_workers: 2
   optimizer: AdamW

--- a/tests/core/models/test_configs/test_schnet.yml
+++ b/tests/core/models/test_configs/test_schnet.yml
@@ -1,19 +1,38 @@
 trainer: forces
 
-task:
-  dataset: lmdb
-  type: regression
-  metric: mae
-  primary_metric: forces_mae
-  labels:
-    - potential energy
-  grad_input: atomic forces
-  train_on_free_atoms: True
-  eval_on_free_atoms: True
-  prediction_dtype: float32
+outputs:
+  energy:
+    shape: 1
+    level: system
+  forces:
+    irrep_dim: 1
+    level: atom
+    train_on_free_atoms: True
+    eval_on_free_atoms: True
 
+loss_functions:
+  - energy:
+      fn: mae
+      coefficient: 2
+  - forces:
+      fn: l2mae
+      coefficient: 100
+
+evaluation_metrics:
+  metrics:
+    energy:
+      - mae
+    forces:
+      - mae
+      - cosine_similarity
+      - magnitude_error
+    misc:
+      - energy_forces_within_threshold
+  primary_metric: forces_mae
+  
 logger:
     name: tensorboard
+
 
 model:
   name: schnet

--- a/tests/core/models/test_configs/test_scn.yml
+++ b/tests/core/models/test_configs/test_scn.yml
@@ -1,20 +1,39 @@
 # A total of 64 32GB GPUs were used for training.
 trainer: forces
 
-task:
-  dataset: lmdb
-  type: regression
-  metric: mae
-  primary_metric: forces_mae
-  labels:
-    - potential energy
-  grad_input: atomic forces
-  train_on_free_atoms: True
-  eval_on_free_atoms: True
-  prediction_dtype: float32
+outputs:
+  energy:
+    shape: 1
+    level: system
+  forces:
+    irrep_dim: 1
+    level: atom
+    train_on_free_atoms: True
+    eval_on_free_atoms: True
 
+loss_functions:
+  - energy:
+      fn: mae
+      coefficient: 2
+  - forces:
+      fn: l2mae
+      coefficient: 100
+
+evaluation_metrics:
+  metrics:
+    energy:
+      - mae
+    forces:
+      - mae
+      - cosine_similarity
+      - magnitude_error
+    misc:
+      - energy_forces_within_threshold
+  primary_metric: forces_mae
+  
 logger:
     name: tensorboard
+
 
 model:
   name: scn


### PR DESCRIPTION
The original hydra commit does not play nice with DDP because there are unused parameters. These parameters are the original heads present in the backbone that are duplicated in the heads. To fix this issue this PR sets them to None in the underlying class when it is used through the Backbone class. 

Additionally tests for DDP versions were not present in the code before this. I have added every network to in tests_e2e to be tested in both DDP and non-DDP modes.
A slight issue with DDP tests is that when using spawn method for distributed we cannot properly pickle and load LMDBs. A workaround for now is when testing with DDP , num_workers=0. 

A future BE task could be to re-initialize LMDB hooks in workers instead of pickling them over. 