### PR TITLE
#806: Move data.db to s3 and download via download_large_files

### DIFF
--- a/docs/core/inference.md
+++ b/docs/core/inference.md
@@ -23,7 +23,8 @@ Boes, J. R., Groenenboom, M. C., Keith, J. A., & Kitchin, J. R. (2016). Neural n
 You can retrieve the dataset below. In this notebook we learn how to do "mass inference" without an ASE calculator. You do this by creating a config.yml file, and running the `main.py` command line utility.
 
 ```{code-cell} ipython3
-! wget https://figshare.com/ndownloader/files/11948267 -O data.db
+from fairchem.core.scripts.download_large_files import download_file_group
+download_file_group('docs')
 ```
 
 

--- a/src/fairchem/core/scripts/download_large_files.py
+++ b/src/fairchem/core/scripts/download_large_files.py
@@ -36,6 +36,7 @@ FILE_GROUPS = {
     "docs": [
         Path("docs/tutorials/NRR/NRR_example_bulks.pkl"),
         Path("docs/core/fine-tuning/supporting-information.json"),
+        Path("docs/core/data.db"),
     ],
 }
 


### PR DESCRIPTION
To resolve transient download error, we will download from s3 via download_large_files. It's not clear if this will 100% resolve the download issue, but we will be able to catch errors and resolve if they arise.