### PR TITLE
Add check to max num atoms

### DIFF
--- a/src/fairchem/core/models/equiformer_v2/equiformer_v2.py
+++ b/src/fairchem/core/models/equiformer_v2/equiformer_v2.py
@@ -397,6 +397,9 @@ class EquiformerV2Backbone(nn.Module, GraphModelMixin):
         self.dtype = data.pos.dtype
         self.device = data.pos.device
         atomic_numbers = data.atomic_numbers.long()
+        assert (
+            atomic_numbers.max().item() < self.max_num_elements
+        ), "Atomic number exceeds that given in model config"
         graph = self.generate_graph(
             data,
             enforce_max_neighbors_strictly=self.enforce_max_neighbors_strictly,

--- a/src/fairchem/core/models/equiformer_v2/equiformer_v2.py
+++ b/src/fairchem/core/models/equiformer_v2/equiformer_v2.py
@@ -467,6 +467,9 @@ class EquiformerV2(nn.Module, GraphModelMixin):
         self.dtype = data.pos.dtype
         self.device = data.pos.device
         atomic_numbers = data.atomic_numbers.long()
+        assert (
+            atomic_numbers.max().item() < self.max_num_elements
+        ), "Atomic number exceeds that given in model config"
         graph = self.generate_graph(
             data,
             enforce_max_neighbors_strictly=self.enforce_max_neighbors_strictly,

--- a/src/fairchem/core/models/escn/escn.py
+++ b/src/fairchem/core/models/escn/escn.py
@@ -235,6 +235,9 @@ class eSCN(nn.Module, GraphModelMixin):
 
         start_time = time.time()
         atomic_numbers = data.atomic_numbers.long()
+        assert (
+            atomic_numbers.max().item() < self.max_num_elements
+        ), "Atomic number exceeds that given in model config"
         num_atoms = len(atomic_numbers)
         graph = self.generate_graph(data)
 

--- a/tests/core/e2e/test_s2ef.py
+++ b/tests/core/e2e/test_s2ef.py
@@ -179,7 +179,7 @@ class TestSmoke:
                     rundir=str(tempdir),
                     update_dict_with={
                         "optim": {"max_epochs": 1},
-                        "model": {"max_num_elements": 2},
+                        "model": {"backbone": {"max_num_elements": 2}},
                         "dataset": oc20_lmdb_train_and_val_from_paths(
                             train_src=str(tutorial_val_src),
                             val_src=str(tutorial_val_src),
@@ -187,7 +187,7 @@ class TestSmoke:
                         ),
                     },
                     update_run_args_with=extra_args,
-                    input_yaml=configs["equiformer_v2"],
+                    input_yaml=configs["equiformer_v2_hydra"],
                 )
 
     @pytest.mark.parametrize(

--- a/tests/core/e2e/test_s2ef.py
+++ b/tests/core/e2e/test_s2ef.py
@@ -170,6 +170,26 @@ class TestSmoke:
                 input_yaml=configs["equiformer_v2"],
             )
 
+    def test_max_num_atoms(self, configs, tutorial_val_src, torch_deterministic):
+        with tempfile.TemporaryDirectory() as tempdirname:
+            tempdir = Path(tempdirname)
+            extra_args = {"seed": 0}
+            with pytest.raises(AssertionError):
+                _ = _run_main(
+                    rundir=str(tempdir),
+                    update_dict_with={
+                        "optim": {"max_epochs": 1},
+                        "model": {"max_num_elements": 2},
+                        "dataset": oc20_lmdb_train_and_val_from_paths(
+                            train_src=str(tutorial_val_src),
+                            val_src=str(tutorial_val_src),
+                            test_src=str(tutorial_val_src),
+                        ),
+                    },
+                    update_run_args_with=extra_args,
+                    input_yaml=configs["equiformer_v2"],
+                )
+
     @pytest.mark.parametrize(
         ("world_size", "ddp"),
         [


### PR DESCRIPTION
If we dont check max num atoms and run on GPU we get a weird CUDA device side assert failure with a line number that has nothing to do with the actual error. This prevents the issue by catching it early and giving a clear error message