### PR TITLE
Use abs run_dir paths by default

### DIFF
--- a/src/fairchem/core/common/flags.py
+++ b/src/fairchem/core/common/flags.py
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 
 
@@ -48,7 +49,7 @@ class Flags:
         )
         self.parser.add_argument(
             "--run-dir",
-            default="./",
+            default=os.path.abspath("./"),
             type=str,
             help="Directory to store checkpoint/log/result directory",
         )


### PR DESCRIPTION
This makes it easier to find people's checkpoints and logs given a W&B run

Currently no idea where these files are :(
<img width="733" alt="image" src="https://github.com/user-attachments/assets/0a216860-7ba6-449e-81a1-3e24fc18d143">


Now: 
<img width="744" alt="image" src="https://github.com/user-attachments/assets/1b92a8cf-0df5-4541-aa0a-926f58c856c0">

we should also add a config line that identifies which cluster the job is on