### PR TITLE
add docstring. Add support for different pseudopotential path

### DIFF
--- a/src/fairchem/data/oc/core/slab.py
+++ b/src/fairchem/data/oc/core/slab.py
@@ -54,7 +54,7 @@ class Slab:
         shift: float | None = None,
         top: bool | None = None,
         oriented_bulk: Structure = None,
-        min_ab: float = 0.8,
+        min_ab: float = 8.0,
     ):
         assert bulk is not None
         self.bulk = bulk

--- a/src/fairchem/data/oc/utils/vasp.py
+++ b/src/fairchem/data/oc/utils/vasp.py
@@ -67,7 +67,9 @@ def calculate_surface_k_points(atoms):
     )
 
 
-def write_vasp_input_files(atoms, outdir=".", vasp_flags=None, pp_setups="minimal"):
+def write_vasp_input_files(
+    atoms, outdir=".", vasp_flags=None, pp_setups="minimal", pp_env="VASP_PP_PATH"
+):
     """
     Effectively goes through the same motions as the `run_vasp` function,
     except it only writes the input files instead of running.
@@ -78,11 +80,14 @@ def write_vasp_input_files(atoms, outdir=".", vasp_flags=None, pp_setups="minima
                     Defaults to '.'
         vasp_flags  A dictionary of settings we want to pass to the `Vasp`
                     calculator. Defaults to a standerd set of values if `None`
+        pp_setups   Pseudopotential setups to use - https://gitlab.com/ase/ase/-/blob/master/ase/calculators/vasp/setups.py
+        pp_env      Environment variable to read for pseudopotentials.
     """
     if vasp_flags is None:  # Immutable default
         vasp_flags = VASP_FLAGS
 
     atoms, vasp_flags = _clean_up_inputs(atoms, vasp_flags.copy())
     calc = Vasp(directory=outdir, **vasp_flags)
+    calc.VASP_PP_PATH = pp_env
     calc.input_params["setups"] = pp_setups
     calc.write_input(atoms)

--- a/src/fairchem/data/oc/utils/vasp_flags.py
+++ b/src/fairchem/data/oc/utils/vasp_flags.py
@@ -42,7 +42,7 @@ SOLVENT_BASE_FLAGS = {
     "xc": "PBE",
     "ivdw": 11,
     "encut": 400.0,
-    "ediff": 1e-6,
+    "ediff": 1e-4,
     "nelm": 100,
     "ismear": 0,
     "sigma": 0.1,


### PR DESCRIPTION
ASE reads the pseudopotenials from `VASP_PP_PATH`. This PR supports the ability to read pseudopotentials from a different environment variable. 