### PR TITLE
explicitly define ispin for oc20 bulks

### DIFF
--- a/src/fairchem/data/oc/utils/vasp_flags.py
+++ b/src/fairchem/data/oc/utils/vasp_flags.py
@@ -24,6 +24,7 @@ BULK_VASP_FLAGS = {
     "ibrion": 1,
     "nsw": 100,
     "isif": 7,
+    "ispin": 1,
     "isym": 0,
     "ediffg": 1e-08,
     "encut": 500.0,

--- a/src/fairchem/data/oc/utils/vasp_flags.py
+++ b/src/fairchem/data/oc/utils/vasp_flags.py
@@ -6,6 +6,7 @@ VASP_FLAGS = {
     "ibrion": 2,
     "nsw": 2000,
     "isif": 0,
+    "ispin": 1,
     "isym": 0,
     "lreal": "Auto",
     "ediffg": -0.03,


### PR DESCRIPTION
Our OC20 bulks don't explicitly define that ISPIN=1. This is a problem when using ASE to generate VASP inputs since if you're using an atoms object that has magnetic moments attached, it will modify your INCAR to be ISPIN=2 even if you don't define it in your vasp flags - https://gitlab.com/ase/ase/-/blob/master/ase/calculators/vasp/create_input.py?ref_type=heads#L72-76.

OC20 used bulks that explicitly did not have magnetic moments attached to their atoms objects, so the dataset remains unaffected. But it is problematic for bulks being used from other sources where magnetic moments are not stripped and if looking for a non spin calculation in line with OC20 models.