### PR TITLE
Add inference_only option to trainers

### DIFF
--- a/src/fairchem/core/common/data_parallel.py
+++ b/src/fairchem/core/common/data_parallel.py
@@ -16,7 +16,7 @@ import numpy as np
 import torch
 import torch.distributed
 from torch.utils.data import BatchSampler, Dataset, DistributedSampler
-from typing_extensions import override
+from typing_extensions import deprecated, override
 
 from fairchem.core.common import distutils, gp_utils
 from fairchem.core.datasets import data_list_collater
@@ -29,6 +29,9 @@ if TYPE_CHECKING:
     from torch_geometric.data import Batch, Data
 
 
+@deprecated(
+    msg="OCPColatter is deprecated. Please use data_list_collater optionally with functools.partial to set defaults"
+)
 class OCPCollater:
     def __init__(self, otf_graph: bool = False) -> None:
         self.otf_graph = otf_graph

--- a/src/fairchem/core/common/data_parallel.py
+++ b/src/fairchem/core/common/data_parallel.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 
 @deprecated(
-    msg="OCPColatter is deprecated. Please use data_list_collater optionally with functools.partial to set defaults"
+    "OCPColatter is deprecated. Please use data_list_collater optionally with functools.partial to set defaults"
 )
 class OCPCollater:
     def __init__(self, otf_graph: bool = False) -> None:

--- a/src/fairchem/core/common/relaxation/ase_utils.py
+++ b/src/fairchem/core/common/relaxation/ase_utils.py
@@ -159,11 +159,6 @@ class OCPCalculator(Calculator):
             config["model_attributes"]["name"] = config.pop("model")
             config["model"] = config["model_attributes"]
 
-        # for checkpoints with relaxation datasets defined, remove to avoid
-        # unnecesarily trying to load that dataset
-        if "relax_dataset" in config.get("task", {}):
-            del config["task"]["relax_dataset"]
-
         # Calculate the edge indices on the fly
         config["model"]["otf_graph"] = True
 

--- a/src/fairchem/core/common/relaxation/ase_utils.py
+++ b/src/fairchem/core/common/relaxation/ase_utils.py
@@ -189,6 +189,7 @@ class OCPCalculator(Calculator):
             is_debug=config.get("is_debug", True),
             cpu=cpu,
             amp=config.get("amp", False),
+            inference_only=True,
         )
 
         if checkpoint_path is not None:

--- a/src/fairchem/core/models/equiformer_v2/equiformer_v2_deprecated.py
+++ b/src/fairchem/core/models/equiformer_v2/equiformer_v2_deprecated.py
@@ -6,6 +6,7 @@ import math
 
 import torch
 import torch.nn as nn
+from typing_extensions import deprecated
 
 from fairchem.core.common import gp_utils
 from fairchem.core.common.registry import registry
@@ -15,7 +16,6 @@ from fairchem.core.models.scn.smearing import GaussianSmearing
 
 with contextlib.suppress(ImportError):
     pass
-
 
 
 from .edge_rot_mat import init_edge_rot_mat
@@ -48,6 +48,7 @@ _AVG_NUM_NODES = 77.81317
 _AVG_DEGREE = 23.395238876342773  # IS2RE: 100k, max_radius = 5, max_neighbors = 100
 
 
+@deprecated()
 @registry.register_model("equiformer_v2")
 class EquiformerV2(nn.Module, GraphModelMixin):
     """
@@ -155,7 +156,7 @@ class EquiformerV2(nn.Module, GraphModelMixin):
         load_energy_lin_ref: bool | None = False,
     ):
         logging.warning(
-            "equiformer_v2 (EquiformerV2) class is deprecaed in favor of equiformer_v2_backbone_and_heads  (EquiformerV2BackboneAndHeads)"
+            "equiformer_v2 (EquiformerV2) class is deprecated in favor of equiformer_v2_backbone_and_heads  (EquiformerV2BackboneAndHeads)"
         )
         if mmax_list is None:
             mmax_list = [2]

--- a/src/fairchem/core/models/equiformer_v2/equiformer_v2_deprecated.py
+++ b/src/fairchem/core/models/equiformer_v2/equiformer_v2_deprecated.py
@@ -6,7 +6,6 @@ import math
 
 import torch
 import torch.nn as nn
-from typing_extensions import deprecated
 
 from fairchem.core.common import gp_utils
 from fairchem.core.common.registry import registry
@@ -48,7 +47,6 @@ _AVG_NUM_NODES = 77.81317
 _AVG_DEGREE = 23.395238876342773  # IS2RE: 100k, max_radius = 5, max_neighbors = 100
 
 
-@deprecated()
 @registry.register_model("equiformer_v2")
 class EquiformerV2(nn.Module, GraphModelMixin):
     """

--- a/src/fairchem/core/trainers/base_trainer.py
+++ b/src/fairchem/core/trainers/base_trainer.py
@@ -642,7 +642,7 @@ class BaseTrainer(ABC):
             if key not in self.elementrefs:
                 self.elementrefs[key] = create_element_references(state_dict=state_dict)
             else:
-                mkeys = self.elementrefs[target_key].load_state_dict(state_dict)
+                mkeys = self.elementrefs[key].load_state_dict(state_dict)
                 assert len(mkeys.missing_keys) == 0
                 assert len(mkeys.unexpected_keys) == 0
 

--- a/src/fairchem/core/trainers/base_trainer.py
+++ b/src/fairchem/core/trainers/base_trainer.py
@@ -17,7 +17,7 @@ import sys
 from abc import ABC, abstractmethod
 from functools import partial
 from itertools import chain
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -67,13 +67,13 @@ if TYPE_CHECKING:
 class BaseTrainer(ABC):
     def __init__(
         self,
-        task,
-        model,
-        outputs,
-        dataset,
-        optimizer,
-        loss_functions,
-        evaluation_metrics,
+        task: dict[str, str | Any],
+        model: dict[str, Any],
+        outputs: dict[str, str | int],
+        dataset: dict[str, str | float],
+        optimizer: dict[str, str | float],
+        loss_functions: dict[str, str | float],
+        evaluation_metrics: dict[str, str],
         identifier: str,
         # TODO: dealing with local rank is dangerous
         # T201111838 remove this and use CUDA_VISIBILE_DEVICES instead so trainers don't need to know about which devie to use
@@ -229,13 +229,15 @@ class BaseTrainer(ABC):
     def load(self) -> None:
         self.load_seed_from_config()
         self.load_logger()
-        self.load_datasets()
-        self.load_references_and_normalizers()
         self.load_task()
         self.load_model()
+        self.load_extras()
+
+        self.load_datasets()
+        self.load_references_and_normalizers()
         self.load_loss()
         self.load_optimizer()
-        self.load_extras()
+
         if self.config["optim"].get("load_datasets_and_model_then_exit", False):
             sys.exit(0)
 

--- a/src/fairchem/core/trainers/base_trainer.py
+++ b/src/fairchem/core/trainers/base_trainer.py
@@ -89,6 +89,7 @@ class BaseTrainer(ABC):
         name: str = "ocp",
         slurm=None,
         gp_gpus: int | None = None,
+        inference_only: bool = False,
     ) -> None:
         if slurm is None:
             slurm = {}
@@ -207,7 +208,7 @@ class BaseTrainer(ABC):
         self.train_dataset = None
         self.val_dataset = None
         self.test_dataset = None
-        self.load()
+        self.load(inference_only)
 
     @abstractmethod
     def train(self, disable_eval_tqdm: bool = False) -> None:
@@ -226,17 +227,18 @@ class BaseTrainer(ABC):
             timestamp_str += "-" + suffix
         return timestamp_str
 
-    def load(self) -> None:
+    def load(self, inference_only: bool) -> None:
         self.load_seed_from_config()
         self.load_logger()
         self.load_task()
         self.load_model()
-        self.load_extras()
 
-        self.load_datasets()
-        self.load_references_and_normalizers()
-        self.load_loss()
-        self.load_optimizer()
+        if inference_only is False:
+            self.load_datasets()
+            self.load_references_and_normalizers()
+            self.load_loss()
+            self.load_optimizer()
+            self.load_extras()
 
         if self.config["optim"].get("load_datasets_and_model_then_exit", False):
             sys.exit(0)

--- a/src/fairchem/core/trainers/ocp_trainer.py
+++ b/src/fairchem/core/trainers/ocp_trainer.py
@@ -302,7 +302,7 @@ class OCPTrainer(BaseTrainer):
 
         return outputs
 
-    def _compute_loss(self, out, batch):
+    def _compute_loss(self, out, batch) -> torch.Tensor:
         batch_size = batch.natoms.numel()
         fixed = batch.fixed
         mask = fixed == 0

--- a/src/fairchem/core/trainers/ocp_trainer.py
+++ b/src/fairchem/core/trainers/ocp_trainer.py
@@ -93,6 +93,7 @@ class OCPTrainer(BaseTrainer):
         name: str = "ocp",
         slurm=None,
         gp_gpus: int | None = None,
+        inference_only: bool = False,
     ):
         if slurm is None:
             slurm = {}
@@ -117,6 +118,7 @@ class OCPTrainer(BaseTrainer):
             slurm=slurm,
             name=name,
             gp_gpus=gp_gpus,
+            inference_only=inference_only,
         )
 
     def train(self, disable_eval_tqdm: bool = False) -> None:

--- a/src/fairchem/core/trainers/ocp_trainer.py
+++ b/src/fairchem/core/trainers/ocp_trainer.py
@@ -11,7 +11,7 @@ import logging
 import os
 from collections import defaultdict
 from itertools import chain
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
@@ -71,28 +71,28 @@ class OCPTrainer(BaseTrainer):
 
     def __init__(
         self,
-        task,
-        model,
-        outputs,
-        dataset,
-        optimizer,
-        loss_functions,
-        evaluation_metrics,
-        identifier,
+        task: dict[str, str | Any],
+        model: dict[str, Any],
+        outputs: dict[str, str | int],
+        dataset: dict[str, str | float],
+        optimizer: dict[str, str | float],
+        loss_functions: dict[str, str | float],
+        evaluation_metrics: dict[str, str],
+        identifier: str,
         # TODO: dealing with local rank is dangerous
         # T201111838 remove this and use CUDA_VISIBILE_DEVICES instead so trainers don't need to know about which devie to use
-        local_rank,
-        timestamp_id=None,
-        run_dir=None,
-        is_debug=False,
-        print_every=100,
-        seed=None,
-        logger="wandb",
-        amp=False,
-        cpu=False,
+        local_rank: int,
+        timestamp_id: str | None = None,
+        run_dir: str | None = None,
+        is_debug: bool = False,
+        print_every: int = 100,
+        seed: int | None = None,
+        logger: str = "wandb",
+        amp: bool = False,
+        cpu: bool = False,
+        name: str = "ocp",
         slurm=None,
-        name="ocp",
-        gp_gpus=None,
+        gp_gpus: int | None = None,
     ):
         if slurm is None:
             slurm = {}
@@ -253,8 +253,9 @@ class OCPTrainer(BaseTrainer):
                 elif isinstance(out[target_key], dict):
                     # if output is a nested dictionary (in the case of hydra models), we attempt to retrieve it using the property name
                     # ie: "output_head_name.property"
-                    assert "property" in self.output_targets[target_key], \
-                        f"we need to know which property to match the target to, please specify the property field in the task config, current config: {self.output_targets[target_key]}"
+                    assert (
+                        "property" in self.output_targets[target_key]
+                    ), f"we need to know which property to match the target to, please specify the property field in the task config, current config: {self.output_targets[target_key]}"
                     property = self.output_targets[target_key]["property"]
                     pred = out[target_key][property]
 
@@ -661,9 +662,7 @@ class OCPTrainer(BaseTrainer):
                 )
                 gather_results["chunk_idx"] = np.cumsum(
                     [gather_results["chunk_idx"][i] for i in idx]
-                )[
-                    :-1
-                ]  # np.split does not need last idx, assumes n-1:end
+                )[:-1]  # np.split does not need last idx, assumes n-1:end
 
                 full_path = os.path.join(
                     self.config["cmd"]["results_dir"], "relaxed_positions.npz"


### PR DESCRIPTION
Add inference_only option to trainers, so that datasets, optimizer, and other objects not necessary for inference are not loaded from checkpoints.

This is mostly for the OCPCalculator, and makes resolves a handful of issues that otherwise arise:
- no need to delete datasets anymore since these will not be loaded
- creating the trainer will not look for files that were used for training but are not necessary for inference (such as normalizers which are already part of the checkpoint)
- no need to specify the specific trainer when loading a checkpoint in `OCPCalculator`, the default `OCPTrainer` should work almost all of the time.

And deprecate `OCPCollater` in favor of using a partial to set otf_graph.