### PR TITLE
ocpapi dependencies / requests -> 2.32.3

### DIFF
--- a/packages/fairchem-demo-ocpapi/pyproject.toml
+++ b/packages/fairchem-demo-ocpapi/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
     "dataclasses-json == 0.6.0",
     "inquirer == 3.1.3",
-    "requests == 2.32.0",
+    "requests == 2.32.3",
     "responses == 0.23.2",
     "tenacity == 8.2.3",
     "tqdm == 4.66.1",


### PR DESCRIPTION
#861 The OCP API package is pinned to requests v2.32.0, which has been yanked. This updates to the most recent version, v2.32.3.