### PR TITLE
fix bug where trainer state not being loaded

### DIFF
--- a/src/fairchem/core/common/relaxation/ase_utils.py
+++ b/src/fairchem/core/common/relaxation/ase_utils.py
@@ -219,7 +219,9 @@ class OCPCalculator(Calculator):
                 Path to trained model
         """
         try:
-            self.trainer.load_checkpoint(checkpoint_path, checkpoint)
+            self.trainer.load_checkpoint(
+                checkpoint_path, checkpoint, inference_only=True
+            )
         except NotImplementedError:
             logging.warning("Unable to load checkpoint!")
 

--- a/src/fairchem/core/trainers/base_trainer.py
+++ b/src/fairchem/core/trainers/base_trainer.py
@@ -601,8 +601,9 @@ class BaseTrainer(ABC):
             if "scheduler" in checkpoint and checkpoint["scheduler"] is not None:
                 self.scheduler.scheduler.load_state_dict(checkpoint["scheduler"])
         else:
-            logging.info("Loading checkpoint in inference-only mode, not loading keys associated with trainer state!")
-
+            logging.info(
+                "Loading checkpoint in inference-only mode, not loading keys associated with trainer state!"
+            )
 
         if "ema" in checkpoint and checkpoint["ema"] is not None:
             self.ema.load_state_dict(checkpoint["ema"])

--- a/src/fairchem/core/trainers/base_trainer.py
+++ b/src/fairchem/core/trainers/base_trainer.py
@@ -578,7 +578,7 @@ class BaseTrainer(ABC):
         self,
         checkpoint_path: str,
         checkpoint: dict | None = None,
-        inference_only: bool | None = None,
+        inference_only: bool = False,
     ) -> None:
         map_location = torch.device("cpu") if self.cpu else self.device
         if checkpoint is None:
@@ -590,7 +590,6 @@ class BaseTrainer(ABC):
             checkpoint = torch.load(checkpoint_path, map_location=map_location)
 
         # attributes that are necessary for training and validation
-        inference_only = self.train_dataset is None or inference_only
         if inference_only is False:
             self.epoch = checkpoint.get("epoch", 0)
             self.step = checkpoint.get("step", 0)
@@ -601,6 +600,9 @@ class BaseTrainer(ABC):
                 self.optimizer.load_state_dict(checkpoint["optimizer"])
             if "scheduler" in checkpoint and checkpoint["scheduler"] is not None:
                 self.scheduler.scheduler.load_state_dict(checkpoint["scheduler"])
+        else:
+            logging.info("Loading checkpoint in inference-only mode, not loading keys associated with trainer state!")
+
 
         if "ema" in checkpoint and checkpoint["ema"] is not None:
             self.ema.load_state_dict(checkpoint["ema"])


### PR DESCRIPTION
Introduced by: https://github.com/FAIR-Chem/fairchem/pull/850/files

inference_only was evaluating to None and not calling the routine to load the trainer state even resuming from training