### PR TITLE
Add script to make release from fine tuned hydra

### DIFF
--- a/src/fairchem/core/scripts/convert_hydra_to_release.py
+++ b/src/fairchem/core/scripts/convert_hydra_to_release.py
@@ -1,0 +1,86 @@
+import argparse
+import logging
+import torch
+import yaml
+
+
+def convert_fine_tune_checkpoint(
+    fine_tune_checkpoint_fn,
+    output_checkpoint_fn,
+    fine_tune_yaml_fn=None,
+    output_yaml_fn=None,
+):
+    fine_tune_checkpoint_fn = fine_tune_checkpoint_fn
+    fine_tune_checkpoint = torch.load(fine_tune_checkpoint_fn, map_location="cpu")
+
+    if "config" not in fine_tune_checkpoint:
+        raise KeyError("Finetune checkpoint does not have a valid 'config' field")
+
+    try:
+        starting_checkpoint_fn = fine_tune_checkpoint["config"]["model"][
+            "finetune_config"
+        ]["starting_checkpoint"]
+    except KeyError as e:
+        logging.error(
+            f"Finetune config missing entry config/model/finetune_config/starting_checkpoint {fine_tune_checkpoint['config']}"
+        )
+        raise e
+
+    starting_checkpoint = torch.load(starting_checkpoint_fn, map_location="cpu")
+    start_checkpoint_model_backbone_config = starting_checkpoint["config"]["model"][
+        "backbone"
+    ]
+
+    fine_tune_checkpoint["config"]["model"][
+        "backbone"
+    ] = start_checkpoint_model_backbone_config
+    fine_tune_checkpoint["config"]["model"].pop("finetune_config")
+
+    torch.save(fine_tune_checkpoint, output_checkpoint_fn)
+
+    # TODO also update config.yml ?
+    if fine_tune_yaml_fn is not None:
+        with open(fine_tune_yaml_fn) as yaml_f:
+            fine_tune_yaml = yaml.safe_load(yaml_f)
+        fine_tune_yaml["model"].pop("finetune_config")
+        fine_tune_yaml["model"]["backbone"] = start_checkpoint_model_backbone_config
+        with open(output_yaml_fn, "w") as yaml_file:
+            yaml.dump(fine_tune_yaml, yaml_file)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fine-tune-checkpoint",
+        help="path to fine tuned checkpoint",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--output-release-checkpoint",
+        help="path to output checkpoint",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--fine-tune-yaml",
+        help="path to fine tune yaml config",
+        type=str,
+        required=False,
+        default=None,
+    )
+    parser.add_argument(
+        "--output-release-yaml",
+        help="path to output yaml config",
+        type=str,
+        required=False,
+        default=None,
+    )
+    args = parser.parse_args()
+
+    convert_fine_tune_checkpoint(
+        fine_tune_yaml_fn=args.fine_tune_yaml,
+        fine_tune_checkpoint_fn=args.fine_tune_checkpoint,
+        output_checkpoint_fn=args.output_release_checkpoint,
+        output_yaml_fn=args.output_release_yaml,
+    )

--- a/tests/core/e2e/test_e2e_commons.py
+++ b/tests/core/e2e/test_e2e_commons.py
@@ -106,7 +106,7 @@ def _run_main(
     save_predictions_to=None,
     world_size=1,
 ):
-    config_yaml = Path(rundir) / "train_and_val_on_val.yml"
+    config_yaml = Path(rundir) / "test_run.yml"
     update_yaml_with_dict(input_yaml, config_yaml, update_dict_with)
     run_args = {
         "run_dir": rundir,
@@ -119,7 +119,17 @@ def _run_main(
     # run
     parser = flags.get_parser()
     args, override_args = parser.parse_known_args(
-        ["--mode", "train", "--seed", "100", "--config-yml", "config.yml", "--cpu", "--num-gpus", str(world_size)]
+        [
+            "--mode",
+            "train",
+            "--seed",
+            "100",
+            "--config-yml",
+            "config.yml",
+            "--cpu",
+            "--num-gpus",
+            str(world_size),
+        ]
     )
     for arg_name, arg_value in run_args.items():
         setattr(args, arg_name, arg_value)

--- a/tests/core/models/test_configs/test_finetune_hydra.yml
+++ b/tests/core/models/test_configs/test_finetune_hydra.yml
@@ -36,7 +36,7 @@ logger:
     name: tensorboard
 
 model:
-  name: finetune_hydra
+  name: hydra
   finetune_config: {}
 
 


### PR DESCRIPTION
When fine tuning a hydra model we use 'starting_checkpoint', however when releasing a model its redundant to ship both the starting checkpoint and the fine tuned checkpoint. 
This script pulls the corresponding config from starting checkpoint and creates a release version of the fine tuned checkpoint that can be used without referencing the original starting checkpoint.