### PR TITLE
add ema to BaseTrainer init

### DIFF
--- a/src/fairchem/core/trainers/base_trainer.py
+++ b/src/fairchem/core/trainers/base_trainer.py
@@ -101,6 +101,7 @@ class BaseTrainer(ABC):
         self.cpu = cpu
         self.epoch = 0
         self.step = 0
+        self.ema = None
 
         if torch.cuda.is_available() and not self.cpu:
             logging.info(f"local rank base: {local_rank}")
@@ -617,7 +618,7 @@ class BaseTrainer(ABC):
                 "Loading checkpoint in inference-only mode, not loading keys associated with trainer state!"
             )
 
-        if "ema" in checkpoint and checkpoint["ema"] is not None:
+        if "ema" in checkpoint and checkpoint["ema"] is not None and self.ema:
             self.ema.load_state_dict(checkpoint["ema"])
         else:
             self.ema = None


### PR DESCRIPTION
This is a follow-up to PR #909

The original changes were made directly on the main branch of my fork. To continue working on my fork, it was necessary to move these changes to a dedicated feature branch and resubmitting them through this PR. The code changes remain the same.

Apologies for the mess!

> Running user-generated models with the OCPCalculator currently raises an error:
'OCPTrainer' object has no attribute 'ema' at line 621 in the load_checkpoint function of base_trainer.py.
>
>This issue occurs because self.ema is not declared when load_checkpoint is called. The ema attribute is currently declared in load_extras rather than in the __init__ method of BaseTrainer, leading to this error if load_extras is not called beforehand. As a best practice, class attributes should only be declared within __init__.
>
>This PR addresses the issue by adding ema initialization to the __init__ function of the BaseTrainer class and includes a check to ensure ema is not None when loading the state dict in load_checkpoint.
>
>This fix resolves the error in my testing.