### PR TITLE
Filter based on additional metadata fields

### DIFF
--- a/src/fairchem/core/datasets/ase_datasets.py
+++ b/src/fairchem/core/datasets/ase_datasets.py
@@ -103,6 +103,8 @@ class AseAtomsDataset(BaseDataset, ABC):
         self.ids = self._load_dataset_get_ids(config)
         self.num_samples = len(self.ids)
 
+        self.info_fields = config.get("info_fields", [])
+
         if len(self.ids) == 0:
             raise ValueError(
                 rf"No valid ase data found! \n"
@@ -130,6 +132,10 @@ class AseAtomsDataset(BaseDataset, ABC):
         data_object = self.a2g.convert(atoms, sid)
         data_object.fid = fid
         data_object.natoms = len(atoms)
+
+        # load additional info from dataset
+        for info_field in self.info_fields:
+            setattr(data_object, info_field, atoms.info.get(info_field))
 
         # apply linear reference
         if self.a2g.r_energy is True and self.lin_ref is not None:

--- a/src/fairchem/core/datasets/ase_datasets.py
+++ b/src/fairchem/core/datasets/ase_datasets.py
@@ -103,8 +103,6 @@ class AseAtomsDataset(BaseDataset, ABC):
         self.ids = self._load_dataset_get_ids(config)
         self.num_samples = len(self.ids)
 
-        self.info_fields = config.get("info_fields", [])
-
         if len(self.ids) == 0:
             raise ValueError(
                 rf"No valid ase data found! \n"
@@ -132,10 +130,6 @@ class AseAtomsDataset(BaseDataset, ABC):
         data_object = self.a2g.convert(atoms, sid)
         data_object.fid = fid
         data_object.natoms = len(atoms)
-
-        # load additional info from dataset
-        for info_field in self.info_fields:
-            setattr(data_object, info_field, atoms.info.get(info_field))
 
         # apply linear reference
         if self.a2g.r_energy is True and self.lin_ref is not None:

--- a/src/fairchem/core/datasets/base_dataset.py
+++ b/src/fairchem/core/datasets/base_dataset.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
-    NamedTuple,
     TypeVar,
 )
 
@@ -109,7 +108,7 @@ class BaseDataset(Dataset[T_co], metaclass=ABCMeta):
         metadata = DatasetMetadata(
             **{
                 field: np.concatenate([metadata[field] for metadata in metadata_npzs])
-                for field in metadata_npzs[0].keys()
+                for field in metadata_npzs[0]
             }
         )
 

--- a/src/fairchem/core/datasets/base_dataset.py
+++ b/src/fairchem/core/datasets/base_dataset.py
@@ -230,11 +230,17 @@ def create_dataset(config: dict[str, Any], split: str) -> Subset:
         # shuffle all datasets by default to avoid biasing the sampling in concat dataset
         # TODO only shuffle if split is train
         max_index = sample_n
-        indices = indices[randperm(len(indices), generator=g)]
+        indices = (
+            indices
+            if len(indices) == 1
+            else indices[randperm(len(indices), generator=g)]
+        )
     else:
         max_index = len(indices)
         indices = (
-            indices if no_shuffle else indices[randperm(len(indices), generator=g)]
+            indices
+            if (no_shuffle or len(indices) == 1)
+            else indices[randperm(len(indices), generator=g)]
         )
 
     if max_index > len(indices):

--- a/src/fairchem/core/datasets/base_dataset.py
+++ b/src/fairchem/core/datasets/base_dataset.py
@@ -66,8 +66,6 @@ class BaseDataset(Dataset[T_co], metaclass=ABCMeta):
         return self.num_samples
 
     def metadata_hasattr(self, attr) -> bool:
-        if self._metadata is None:
-            return False
         return attr in self._metadata
 
     @cached_property
@@ -128,7 +126,7 @@ class Subset(Subset_, BaseDataset):
         self,
         dataset: BaseDataset,
         indices: Sequence[int],
-        metadata: DatasetMetadata | None = None,
+        metadata: dict[str, ArrayLike],
     ) -> None:
         super().__init__(dataset, indices)
         self.metadata = metadata
@@ -137,7 +135,7 @@ class Subset(Subset_, BaseDataset):
         self.config = dataset.config
 
     @cached_property
-    def _metadata(self) -> DatasetMetadata:
+    def _metadata(self) -> dict[str, ArrayLike]:
         return self.dataset._metadata
 
     def get_metadata(self, attr, idx):

--- a/src/fairchem/core/datasets/base_dataset.py
+++ b/src/fairchem/core/datasets/base_dataset.py
@@ -94,7 +94,7 @@ class BaseDataset(Dataset[T_co], metaclass=ABCMeta):
             logging.warning(
                 f"Could not find dataset metadata.npz files in '{self.paths}'"
             )
-            return None
+            return {}
 
         metadata = {
             field: np.concatenate([metadata[field] for metadata in metadata_npzs])
@@ -111,7 +111,7 @@ class BaseDataset(Dataset[T_co], metaclass=ABCMeta):
         return metadata
 
     def get_metadata(self, attr, idx):
-        if self._metadata is not None:
+        if attr in self._metadata:
             metadata_attr = self._metadata[attr]
             if isinstance(idx, list):
                 return [metadata_attr[_idx] for _idx in idx]

--- a/src/fairchem/core/datasets/base_dataset.py
+++ b/src/fairchem/core/datasets/base_dataset.py
@@ -34,8 +34,11 @@ if TYPE_CHECKING:
 T_co = TypeVar("T_co", covariant=True)
 
 
-class DatasetMetadata(NamedTuple):
-    natoms: ArrayLike | None = None
+class DatasetMetadata:
+    def __init__(self, natoms: ArrayLike | None = None, **kwargs):
+        self.natoms = natoms
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
 
 class UnsupportedDatasetError(ValueError):
@@ -106,9 +109,10 @@ class BaseDataset(Dataset[T_co], metaclass=ABCMeta):
         metadata = DatasetMetadata(
             **{
                 field: np.concatenate([metadata[field] for metadata in metadata_npzs])
-                for field in DatasetMetadata._fields
+                for field in metadata_npzs[0].keys()
             }
         )
+
         assert np.issubdtype(
             metadata.natoms.dtype, np.integer
         ), f"Metadata natoms must be an integer type! not {metadata.natoms.dtype}"

--- a/tests/core/datasets/test_create_dataset.py
+++ b/tests/core/datasets/test_create_dataset.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import os
+import tempfile
+
 import numpy as np
 import pytest
 
 from fairchem.core.datasets import LMDBDatabase, create_dataset
 from fairchem.core.datasets.base_dataset import BaseDataset
-import tempfile
 from fairchem.core.trainers.base_trainer import BaseTrainer
 
 
@@ -12,12 +15,21 @@ from fairchem.core.trainers.base_trainer import BaseTrainer
 def lmdb_database(structures):
     with tempfile.TemporaryDirectory() as tmpdirname:
         num_atoms = []
+        mod2 = []
+        mod3 = []
         asedb_fn = f"{tmpdirname}/asedb.lmdb"
         with LMDBDatabase(asedb_fn) as database:
             for i, atoms in enumerate(structures):
                 database.write(atoms, data=atoms.info)
                 num_atoms.append(len(atoms))
-        np.savez(f"{tmpdirname}/metadata.npz", natoms=num_atoms)
+                mod2.append(len(atoms) % 2)
+                mod3.append(len(atoms) % 3)
+        np.savez(
+            f"{tmpdirname}/metadata.npz",
+            natoms=num_atoms,
+            mod2=mod2,
+            mod3=mod3,
+        )
         yield asedb_fn
 
 
@@ -74,6 +86,40 @@ def test_real_dataset_config(lmdb_database):
     t.load_datasets()
     assert len(t.train_dataset) == 2
     assert len(t.val_dataset) == 3
+
+
+def test_subset_to(structures, lmdb_database):
+    config = {
+        "format": "ase_db",
+        "src": str(lmdb_database),
+        "subset_to": [{"op": "abs_le", "metadata_key": "mod2", "rhv": 10}],
+    }
+
+    assert len(create_dataset(config, split="train")) == len(structures)
+
+    # only select those that have mod2==0
+    config = {
+        "format": "ase_db",
+        "src": str(lmdb_database),
+        "subset_to": [{"op": "abs_le", "metadata_key": "mod2", "rhv": 0}],
+    }
+    assert len(create_dataset(config, split="train")) == len(
+        [s for s in structures if len(s) % 2 == 0]
+    )
+
+    # only select those that have mod2==0 and mod3==0
+    config = {
+        "format": "ase_db",
+        "src": str(lmdb_database),
+        "subset_to": [
+            {"op": "abs_le", "metadata_key": "mod2", "rhv": 0},
+            {"op": "abs_le", "metadata_key": "mod2", "rhv": 0},
+        ],
+    }
+    assert len(create_dataset(config, split="train")) == len(
+        [s for s in structures if len(s) % 2 == 0]
+    )
+    assert len([s for s in structures if len(s) % 2 == 0]) > 0
 
 
 @pytest.mark.parametrize("max_atoms", [3, None])

--- a/tests/core/datasets/test_create_dataset.py
+++ b/tests/core/datasets/test_create_dataset.py
@@ -140,7 +140,7 @@ def test_create_dataset(key, value, max_atoms, structures, lmdb_database):
         structures = [s for s in structures if len(s) <= max_atoms]
         assert all(
             natoms <= max_atoms
-            for natoms in dataset.metadata.natoms[range(len(dataset))]
+            for natoms in dataset.metadata["natoms"][range(len(dataset))]
         )
     if key == "first_n":  # this assumes first_n are not shuffled
         assert all(


### PR DESCRIPTION
Extend metadata with additional fields present in the NPZ metadata file. Instead of just taking 'natoms' take everything that is present. 
Allow user to specify a filter on the dataset in the format of 

Take all indices that have absolute value of 'some_quantity' less then or equal to 5
```
subset_to:
  - op: abs_le
     metadata_key: some_quantity
     rhv: 5
```

Take all indices that a value of 'some_quantity' in [x,y,z]
```
subset_to:
  - op: in
     metadata_key: some_quantity
     rhv: [x,y,z]
```