### PR TITLE
Add structured configs to hydra cli, pass cfg to runners

### DIFF
--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -33,6 +33,7 @@ adsorbml = ["dscribe","x3dase","scikit-image"]
 
 [project.scripts]
 fairchem = "fairchem.core._cli:main"
+fairchemv2 = "fairchem.core._cli_hydra:main"
 
 [project.urls]
 repository = "https://github.com/FAIR-Chem/fairchem"

--- a/src/fairchem/core/_cli.py
+++ b/src/fairchem/core/_cli.py
@@ -68,12 +68,6 @@ def main(
         parser: argparse.ArgumentParser = flags.get_parser()
         args, override_args = parser.parse_known_args()
 
-    if args.hydra:
-        from fairchem.core._cli_hydra import main
-
-        main(args, override_args)
-        return
-
     # TODO: rename num_gpus -> num_ranks everywhere
     assert (
         args.num_gpus > 0

--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -80,11 +80,11 @@ class Submitit(Checkpointable):
         # TODO: setup_imports is not needed if we stop instantiating models with Registry.
         setup_imports()
         setup_env_vars()
-        distutils.setup(map_job_config_to_dist_config(dict_config.job))
+        distutils.setup(map_job_config_to_dist_config(self.config.job))
         self._init_logger()
         runner: Runner = hydra.utils.instantiate(dict_config.runner)
         runner.load_state()
-        runner.run(self.config)
+        runner.run(self.config.job)
         distutils.cleanup()
 
     def _init_logger(self) -> None:

--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -84,7 +84,7 @@ class Submitit(Checkpointable):
         self._init_logger()
         runner: Runner = hydra.utils.instantiate(dict_config.runner)
         runner.load_state()
-        runner.run()
+        runner.run(self.config)
         distutils.cleanup()
 
     def _init_logger(self) -> None:

--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
 
 from submitit import AutoExecutor
 from submitit.helpers import Checkpointable, DelayedSubmission
-from torch.distributed.launcher.api import LaunchConfig, elastic_launch
 
 from fairchem.core.common import distutils
 from fairchem.core.common.utils import get_timestamp_uid, setup_env_vars, setup_imports
@@ -184,6 +183,8 @@ def main(
             f"Submitted job id: {job_cfg.timestamp_id}, slurm id: {job.job_id}, logs: {job_cfg.log_dir}"
         )
     else:
+        from torch.distributed.launcher.api import LaunchConfig, elastic_launch
+
         if scheduler_cfg.ranks_per_node > 1:
             logging.info(f"Running in local mode with {job_cfg.ranks_per_node} ranks")
             launch_config = LaunchConfig(

--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -7,16 +7,18 @@ LICENSE file in the root directory of this source tree.
 
 from __future__ import annotations
 
+import argparse
 import logging
 import os
+import tempfile
+import uuid
+from enum import Enum
 from typing import TYPE_CHECKING
 
 import hydra
 from omegaconf import OmegaConf
 
 if TYPE_CHECKING:
-    import argparse
-
     from omegaconf import DictConfig
 
     from fairchem.core.components.runner import Runner
@@ -27,11 +29,59 @@ from submitit.helpers import Checkpointable, DelayedSubmission
 from torch.distributed.launcher.api import LaunchConfig, elastic_launch
 
 from fairchem.core.common import distutils
-from fairchem.core.common.flags import flags
 from fairchem.core.common.utils import get_timestamp_uid, setup_env_vars, setup_imports
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+# this effects the cli only since the actual job will be run in subprocesses or remoe
+logging.basicConfig(level=logging.INFO)
+
+
+class SchedulerType(str, Enum):
+    LOCAL = "local"
+    SLURM = "slurm"
+
+
+class DeviceType(str, Enum):
+    CPU = "cpu"
+    CUDA = "cuda"
+
+
+class SchedulerConfig:
+    scheduler_type: SchedulerType = SchedulerType.LOCAL
+    ranks_per_node: int = 1
+    num_nodes: int = 1
+    slurm: dict = None
+
+    def __post_init__(self):
+        defaults = {
+            "slurm_mem": 80,  # slurm mem in GB
+            "timeout_min": 4320,  # slurm timeout in mins, default to 7 days
+            "slurm_partition": None,
+            "cpus_per_task": 8,
+            "slurm_qos": None,
+            "slurm_account": None,
+        }
+        # fuse defaults with user inputs
+        self.slurm = defaults.update(self.slurm)
+
+
+class FairchemJobConfig:
+    def __init__(
+        self,
+        run_name: str | None = None,
+        timestamp_id: str | None = None,
+        run_dir: str | None = None,
+        log_dir: str | None = None,
+        device_type: DeviceType = DeviceType.CUDA,
+    ):
+        self.run_name = run_name or uuid.uuid4().hex.upper()[0:8]
+        self.timestamp_id = timestamp_id or get_timestamp_uid()
+        self.device_type = device_type
+        if not run_dir:
+            self.run_dir = tempfile.TemporaryDirectory().name
+        if not log_dir:
+            self.log_dir = os.path.join(self.run_dir, self.timestamp_id, "logs")
+        os.makedirs(self.run_dir, exist_ok=True)
+        os.makedirs(self.log_dir, exist_ok=True)
 
 
 class Submitit(Checkpointable):
@@ -94,7 +144,7 @@ def get_hydra_config_from_yaml(
     os.environ["HYDRA_FULL_ERROR"] = "1"
     config_directory = os.path.dirname(os.path.abspath(config_yml))
     config_name = os.path.basename(config_yml)
-    hydra.initialize_config_dir(config_directory)
+    hydra.initialize_config_dir(config_directory, version_base="1.1")
     return hydra.compose(config_name=config_name, overrides=overrides_args)
 
 
@@ -102,62 +152,49 @@ def runner_wrapper(config: DictConfig):
     Submitit()(config)
 
 
-# this is meant as a future replacement for the main entrypoint
 def main(
     args: argparse.Namespace | None = None, override_args: list[str] | None = None
 ):
     if args is None:
-        parser: argparse.ArgumentParser = flags.get_parser()
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--config-yml", type=str, required=True)
         args, override_args = parser.parse_known_args()
 
     cfg = get_hydra_config_from_yaml(args.config_yml, override_args)
-    timestamp_id = get_timestamp_uid()
-    log_dir = os.path.join(args.run_dir, timestamp_id, "logs")
-    # override timestamp id and logdir
-    args.timestamp_id = timestamp_id
-    args.logdir = log_dir
-    os.makedirs(log_dir)
-    OmegaConf.update(cfg, "cli_args", vars(args), force_add=True)
-    if args.submit:  # Run on cluster
-        executor = AutoExecutor(folder=log_dir, slurm_max_num_timeout=3)
+    job_cfg: FairchemJobConfig = hydra.utils.instantiate(cfg.job)
+    scheduler: SchedulerConfig = hydra.utils.instantiate(cfg.scheduler)
+    logging.info(f"Running fairchemv2 cli with {job_cfg}, {scheduler}")
+
+    if job_cfg.scheduler_type == SchedulerType.SLURM:  # Run on cluster
+        executor = AutoExecutor(folder=job_cfg.log_dir, slurm_max_num_timeout=3)
         executor.update_parameters(
-            name=args.identifier,
-            mem_gb=args.slurm_mem,
-            timeout_min=args.slurm_timeout * 60,
-            slurm_partition=args.slurm_partition,
-            gpus_per_node=args.num_gpus,
-            cpus_per_task=8,
-            tasks_per_node=args.num_gpus,
-            nodes=args.num_nodes,
-            slurm_qos=args.slurm_qos,
-            slurm_account=args.slurm_account,
+            name=job_cfg.run_name,
+            mem_gb=scheduler.slurm.slurm_mem,
+            timeout_min=scheduler.slurm.slurm_timeout * 60,
+            slurm_partition=scheduler.slurm.slurm_partition,
+            gpus_per_node=scheduler.num_gpus,
+            cpus_per_task=scheduler.slurm.cpus_per_task,
+            tasks_per_node=scheduler.num_gpus,
+            nodes=scheduler.num_nodes,
+            slurm_qos=scheduler.slurm.slurm_qos,
+            slurm_account=scheduler.slurm.slurm_account,
         )
         job = executor.submit(runner_wrapper, cfg)
-        logger.info(
-            f"Submitted job id: {timestamp_id}, slurm id: {job.job_id}, logs: {log_dir}"
+        logging.info(
+            f"Submitted job id: {job_cfg.timestamp_id}, slurm id: {job.job_id}, logs: {job_cfg.log_dir}"
         )
     else:
-        if args.num_gpus > 1:
-            logging.info(f"Running in local mode with {args.num_gpus} ranks")
-            # HACK to disable multiprocess dataloading in local mode
-            # there is an open issue where LMDB's environment cannot be pickled and used
-            # during torch multiprocessing https://github.com/pytorch/examples/issues/526
-            # this HACK only works for a training submission where the config is passed in here
-            if "optim" in cfg and "num_workers" in cfg["optim"]:
-                cfg["optim"]["num_workers"] = 0
-                logging.info(
-                    "WARNING: running in local mode, setting dataloading num_workers to 0, see https://github.com/pytorch/examples/issues/526"
-                )
-
+        if scheduler.num_gpus > 1:
+            logging.info(f"Running in local mode with {job_cfg.num_gpus} ranks")
             launch_config = LaunchConfig(
                 min_nodes=1,
                 max_nodes=1,
-                nproc_per_node=args.num_gpus,
+                nproc_per_node=scheduler.num_gpus,
                 rdzv_backend="c10d",
                 max_restarts=0,
             )
             elastic_launch(launch_config, runner_wrapper)(cfg)
         else:
-            logger.info("Running in local mode without elastic launch")
+            logging.info("Running in local mode without elastic launch")
             distutils.setup_env_local()
             runner_wrapper(cfg)

--- a/src/fairchem/core/common/flags.py
+++ b/src/fairchem/core/common/flags.py
@@ -121,11 +121,6 @@ class Flags:
             "--cpu", action="store_true", help="Run CPU only training"
         )
         self.parser.add_argument(
-            "--hydra",
-            action="store_true",
-            help="Use hydra configs instead (in development)",
-        )
-        self.parser.add_argument(
             "--num-nodes",
             default=1,
             type=int,

--- a/src/fairchem/core/components/runner.py
+++ b/src/fairchem/core/components/runner.py
@@ -44,7 +44,6 @@ class MockRunner(Runner):
         self.y = y
 
     def run(self) -> Any:
-        assert hasattr(self, "fairchem_config")
         if self.x * self.y > 1000:
             raise ValueError("sum is greater than 1000!")
         return self.x + self.y

--- a/src/fairchem/core/components/runner.py
+++ b/src/fairchem/core/components/runner.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
+    from fairchem.core._cli_hydra import FairchemJobConfig
+
 
 class Runner(metaclass=ABCMeta):
     """
@@ -14,8 +16,16 @@ class Runner(metaclass=ABCMeta):
     This allows us to decouple away from a monolithic trainer class
     """
 
+    @property
+    def fairchem_config(self) -> FairchemJobConfig:
+        return self._fairchem_config
+
+    @fairchem_config.setter
+    def fairchem_config(self, cfg: DictConfig):
+        self._fairchem_config = cfg
+
     @abstractmethod
-    def run(self, cfg: DictConfig = None) -> Any:
+    def run(self) -> Any:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/fairchem/core/components/runner.py
+++ b/src/fairchem/core/components/runner.py
@@ -43,7 +43,8 @@ class MockRunner(Runner):
         self.x = x
         self.y = y
 
-    def run(self, cfg: DictConfig = None) -> Any:
+    def run(self) -> Any:
+        assert hasattr(self, "fairchem_config")
         if self.x * self.y > 1000:
             raise ValueError("sum is greater than 1000!")
         return self.x + self.y

--- a/src/fairchem/core/components/runner.py
+++ b/src/fairchem/core/components/runner.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
-    from fairchem.core._cli_hydra import FairchemJobConfig
+    from fairchem.core._cli_hydra import JobConfig
 
 
 class Runner(metaclass=ABCMeta):
@@ -17,12 +17,12 @@ class Runner(metaclass=ABCMeta):
     """
 
     @property
-    def fairchem_config(self) -> FairchemJobConfig:
-        return self._fairchem_config
+    def job_config(self) -> JobConfig:
+        return self._job_config
 
-    @fairchem_config.setter
-    def fairchem_config(self, cfg: DictConfig):
-        self._fairchem_config = cfg
+    @job_config.setter
+    def job_config(self, cfg: DictConfig):
+        self._job_config = cfg
 
     @abstractmethod
     def run(self) -> Any:

--- a/src/fairchem/core/components/runner.py
+++ b/src/fairchem/core/components/runner.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
 
 
 class Runner(metaclass=ABCMeta):
@@ -12,7 +15,7 @@ class Runner(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def run(self) -> Any:
+    def run(self, cfg: DictConfig = None) -> Any:
         raise NotImplementedError
 
     @abstractmethod
@@ -30,7 +33,7 @@ class MockRunner(Runner):
         self.x = x
         self.y = y
 
-    def run(self) -> Any:
+    def run(self, cfg: DictConfig = None) -> Any:
         if self.x * self.y > 1000:
             raise ValueError("sum is greater than 1000!")
         return self.x + self.y

--- a/tests/core/test_hydra_cli.py
+++ b/tests/core/test_hydra_cli.py
@@ -5,14 +5,14 @@ import sys
 import hydra
 import pytest
 
-from fairchem.core._cli import main
+from fairchem.core._cli_hydra import main
 from fairchem.core.common import distutils
 
 
 def test_hydra_cli():
     distutils.cleanup()
     hydra.core.global_hydra.GlobalHydra.instance().clear()
-    sys_args = ["--hydra", "--config-yml", "tests/core/test_hydra_cli.yml", "--cpu"]
+    sys_args = ["--config-yml", "tests/core/test_hydra_cli.yml"]
     sys.argv[1:] = sys_args
     main()
 
@@ -21,8 +21,6 @@ def test_hydra_cli_throws_error():
     distutils.cleanup()
     hydra.core.global_hydra.GlobalHydra.instance().clear()
     sys_args = [
-        "--hydra",
-        "--cpu",
         "--config-yml",
         "tests/core/test_hydra_cli.yml",
         "runner.x=1000",
@@ -38,8 +36,6 @@ def test_hydra_cli_throws_error_on_invalid_inputs():
     distutils.cleanup()
     hydra.core.global_hydra.GlobalHydra.instance().clear()
     sys_args = [
-        "--hydra",
-        "--cpu",
         "--config-yml",
         "tests/core/test_hydra_cli.yml",
         "runner.x=1000",

--- a/tests/core/test_hydra_cli.yml
+++ b/tests/core/test_hydra_cli.yml
@@ -1,3 +1,8 @@
+job:
+  device_type: CPU
+  scheduler:
+    mode: LOCAL
+
 runner:
   _target_: fairchem.core.components.runner.MockRunner
   x: 10


### PR DESCRIPTION
1. Removes hydra_cli and cli dependency and splits them into two different clis
The new cli will be called like:
`fairchemv2 --config-yml /path/to/yaml [hydra-like config overides]`

This removes the old arg flags completely and moves them into FairchemJobConfig as a structured config:

Users are free to specify the either in the yaml or in the command line as they choose
in yaml:

``` 
job:
  scheduler:
    num_ranks_per_node: 4

runner:

logger:
```

in command line:
`fairchemv2 --config-yml /path/to/yaml +job.scheduler.num_ranks_per_node=4`

2. Pass the job config to the runner as a property, the runner still some needs some system level params such as run_dir
ie: runner.fairchem_config