### PR TITLE
Allow dataset subset to read in path to rhv

### DIFF
--- a/src/fairchem/core/datasets/base_dataset.py
+++ b/src/fairchem/core/datasets/base_dataset.py
@@ -189,17 +189,16 @@ def create_dataset(config: dict[str, Any], split: str) -> Subset:
             raise ValueError(
                 f"Cannot use {subset_to} without dataset metadata key {subset_to['metadata_key']}"
             )
+        rhv = subset_to["rhv"]
+        if isinstance(rhv, str):
+            with open(rhv) as f:
+                rhv = f.read().splitlines()
+                rhv = [int(x) for x in rhv]
         if subset_to["op"] == "abs_le":
-            indices = indices[
-                np.abs(dataset.get_metadata(subset_to["metadata_key"], indices))
-                <= subset_to["rhv"]
-            ]
+            indices = indices[np.rhv <= rhv]
         elif subset_to["op"] == "in":
             indices = indices[
-                np.isin(
-                    dataset.get_metadata(subset_to["metadata_key"], indices),
-                    subset_to["rhv"],
-                )
+                np.isin(dataset.get_metadata(subset_to["metadata_key"], indices), rhv)
             ]
 
     # Apply dataset level transforms

--- a/src/fairchem/core/datasets/base_dataset.py
+++ b/src/fairchem/core/datasets/base_dataset.py
@@ -195,7 +195,9 @@ def create_dataset(config: dict[str, Any], split: str) -> Subset:
                 rhv = f.read().splitlines()
                 rhv = [int(x) for x in rhv]
         if subset_to["op"] == "abs_le":
-            indices = indices[np.rhv <= rhv]
+            indices = indices[
+                np.abs(dataset.get_metadata(subset_to["metadata_key"], indices)) <= rhv
+            ]
         elif subset_to["op"] == "in":
             indices = indices[
                 np.isin(dataset.get_metadata(subset_to["metadata_key"], indices), rhv)

--- a/tests/core/datasets/test_create_dataset.py
+++ b/tests/core/datasets/test_create_dataset.py
@@ -98,7 +98,7 @@ def test_subset_to(structures, lmdb_database):
 
     assert len(create_dataset(config, split="train")) == len(structures)
 
-    # select a subset of indices
+    # select a subset of indices fed as list
     indices = [1, 2]
     config = {
         "format": "ase_db",
@@ -107,6 +107,22 @@ def test_subset_to(structures, lmdb_database):
     }
 
     assert len(create_dataset(config, split="train")) == len(indices)
+
+    # select a subset of indices fed as path
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        indices_path = f"{tmpdirname}/indices.txt"
+        indices = [1, 2]
+        with open(indices_path, "w") as f:
+            for idx in indices:
+                f.write(f"{idx}\n")
+
+        config = {
+            "format": "ase_db",
+            "src": str(lmdb_database),
+            "subset_to": [{"op": "in", "metadata_key": "mod2", "rhv": indices_path}],
+        }
+
+        assert len(create_dataset(config, split="train")) == len(indices)
 
     # only select those that have mod2==0
     config = {


### PR DESCRIPTION
Allow users to provide a text file for `rhv` rather than inputing them directly in config. Mainly helpful for OC20 if you want to filter on sids when there's 600k+. 