### PR TITLE
Preserve custom trainer name

### DIFF
--- a/src/fairchem/core/common/utils.py
+++ b/src/fairchem/core/common/utils.py
@@ -1057,7 +1057,7 @@ def new_trainer_context(*, config: dict[str, Any]):
     elif "multitask" in trainer_name:
         task_name = "multitask"
     else:
-        task_name = "ocp"
+        task_name = trainer_name
 
     trainer_cls = registry.get_trainer_class(trainer_name)
     assert trainer_cls is not None, "Trainer not found"

--- a/src/fairchem/core/common/utils.py
+++ b/src/fairchem/core/common/utils.py
@@ -1076,7 +1076,7 @@ def new_trainer_context(*, config: dict[str, Any]):
         "amp": config.get("amp", False),
         "cpu": config.get("cpu", False),
         "slurm": config.get("slurm", {}),
-        "name": task_name,
+        "name": trainer_name,
         "gp_gpus": config.get("gp_gpus"),
     }
 

--- a/src/fairchem/core/trainers/ocp_trainer.py
+++ b/src/fairchem/core/trainers/ocp_trainer.py
@@ -136,7 +136,7 @@ class OCPTrainer(BaseTrainer):
         eval_every = self.config["optim"].get("eval_every", len(self.train_loader))
         checkpoint_every = self.config["optim"].get("checkpoint_every", eval_every)
         primary_metric = self.evaluation_metrics.get(
-            "primary_metric", self.evaluator.task_primary_metric[self.name]
+            "primary_metric", self.evaluator.task_primary_metric.get(self.name)
         )
         if not hasattr(self, "primary_metric") or self.primary_metric != primary_metric:
             self.best_val_metric = 1e9 if "mae" in primary_metric else -1.0


### PR DESCRIPTION
I'm using a subclass of OCPTrainer and noticed the trainer name isn't saved as I would expect. This is a problem when I'm trying to use a checkpoint and the trainer config['name'] is 'ocp' instead of my custom trainer name so it looks up the wrong trainer in the registry. 

Perhaps someone with better knowledge of the codebase has a better sense of what's going on but to me it appears to be an issue in the `new_trainer_context` function:
https://github.com/FAIR-Chem/fairchem/blob/d513ffa6f638a0f4c0f16e31dfa8f7469b36bb2f/src/fairchem/core/common/utils.py#L1051-L1079
The trainer config name is set to the task_name which is hardcoded to 'ocp'. My fix is to simply preserve the trainer name.

EDIT:
I think this is also causing the following issue or is related: https://github.com/FAIR-Chem/fairchem/issues/635
Maybe someone who knows better can untangle the task name vs trainer name thing here. Seems like a wider problem in the trainer classes.

It's confounded by this:
OCPTrainer tries to look up task_primary_metric by self.name (which should be the trainer name) but the evaluator naturally stores task_primary_metric by task name. 
https://github.com/FAIR-Chem/fairchem/blob/main/src/fairchem/core/trainers/ocp_trainer.py#L138-L140

https://github.com/FAIR-Chem/fairchem/blob/main/src/fairchem/core/modules/evaluator.py#L71-L75