### PR TITLE
Fix OCPNeb trainer loading

### DIFF
--- a/src/fairchem/applications/cattsunami/core/ocpneb.py
+++ b/src/fairchem/applications/cattsunami/core/ocpneb.py
@@ -36,6 +36,7 @@ class OCPNEB(DyNEB):
         precon=None,
         cpu=False,
         batch_size=4,
+        trainer=None,
     ):
         """
         Subclass of NEB that allows for scaled and dynamic optimizations of
@@ -97,11 +98,14 @@ class OCPNEB(DyNEB):
         if "relax_dataset" in config["task"]:
             del config["task"]["relax_dataset"]
 
-        self.trainer = registry.get_trainer_class(config.get("trainer", "ocp"))(
+        if trainer is None:
+            trainer = config.get("trainer", "ocp")
+
+        self.trainer = registry.get_trainer_class(trainer)(
             task=config.get("task", {}),
             model=config["model"],
             outputs={},
-            loss_functions={},
+            loss_functions=config["loss_functions"],
             evaluation_metrics={},
             dataset=[config["dataset"]],
             optimizer=config["optim"],

--- a/src/fairchem/applications/cattsunami/core/ocpneb.py
+++ b/src/fairchem/applications/cattsunami/core/ocpneb.py
@@ -105,7 +105,7 @@ class OCPNEB(DyNEB):
             task=config.get("task", {}),
             model=config["model"],
             outputs={},
-            loss_functions=config["loss_functions"],
+            loss_functions=config.get("loss_functions", {}),
             evaluation_metrics={},
             dataset=[config["dataset"]],
             optimizer=config["optim"],


### PR DESCRIPTION
OCPNeb loading of fine tuned models is broken (#981) 

This can be reproduced when training, or finetuning any new model and passing it to OCPNeb. The reason here is that our loader uses the 'trainer' field in config to query the registry. 
However we populate the 'trainer' field with the task_name [here](https://github.com/FAIR-Chem/fairchem/blob/2e49a4efb5a8a5a175795f7898d16e3cbbfbdb71/src/fairchem/core/common/utils.py#L1079) and [here](https://github.com/FAIR-Chem/fairchem/blob/2e49a4efb5a8a5a175795f7898d16e3cbbfbdb71/src/fairchem/core/trainers/base_trainer.py#L128C14-L128C21)
To fix this we normally load models using OCPCalculator and pass the explicit trainer name in as an argument overriding the one present in the checkpoint. 
However OCPNeb does not have this option to pass in trainer specifically, and only uses the one present in the checkpoint, which has trainer='s2ef', however 's2ef' is not a valid trainer so this fails.

Additionally when OCPNeb calls the trainer initialization it does not pass through loss_functions, but loss_functions is used as a early return condition in update_config, which if not present will fail on updated configs as they try to get converted but cant.

This PR fixes (hopefully) both issues and unblocks #981 