### PR TITLE
update reduction to mean in omat24 configs

### DIFF
--- a/configs/omat24/all/eqV2_153M.yml
+++ b/configs/omat24/all/eqV2_153M.yml
@@ -52,7 +52,7 @@ loss_functions:
       coefficient: 5
   - stress_anisotropic:
       fn: mae
-      reduction: mean_all
+      reduction: mean
       coefficient: 5
 
 optim:

--- a/configs/omat24/all/eqV2_31M.yml
+++ b/configs/omat24/all/eqV2_31M.yml
@@ -53,7 +53,7 @@ loss_functions:
       coefficient: 5
   - stress_anisotropic:
       fn: mae
-      reduction: mean_all
+      reduction: mean
       coefficient: 5
 
 

--- a/configs/omat24/all/eqV2_86M.yml
+++ b/configs/omat24/all/eqV2_86M.yml
@@ -52,7 +52,7 @@ loss_functions:
       coefficient: 5
   - stress_anisotropic:
       fn: mae
-      reduction: mean_all
+      reduction: mean
       coefficient: 5
 
 optim:

--- a/configs/omat24/finetune/eqV2_153M_ft_salexmptrj.yml
+++ b/configs/omat24/finetune/eqV2_153M_ft_salexmptrj.yml
@@ -54,7 +54,7 @@ loss_functions:
       coefficient: 1
   - stress_anisotropic:
       fn: mae
-      reduction: mean_all
+      reduction: mean
       coefficient: 1
 
 model:

--- a/configs/omat24/finetune/eqV2_31M_ft_salexmptrj.yml
+++ b/configs/omat24/finetune/eqV2_31M_ft_salexmptrj.yml
@@ -54,7 +54,7 @@ loss_functions:
       coefficient: 1
   - stress_anisotropic:
       fn: mae
-      reduction: mean_all
+      reduction: mean
       coefficient: 1
 
 model:

--- a/configs/omat24/finetune/eqV2_86M_ft_salexmptrj.yml
+++ b/configs/omat24/finetune/eqV2_86M_ft_salexmptrj.yml
@@ -52,7 +52,7 @@ loss_functions:
       coefficient: 1
   - stress_anisotropic:
       fn: mae
-      reduction: mean_all
+      reduction: mean
       coefficient: 1
 
 hide_eval_progressbar: False

--- a/configs/omat24/mptrj/eqV2_153M_dens_mptrj.yml
+++ b/configs/omat24/mptrj/eqV2_153M_dens_mptrj.yml
@@ -54,7 +54,7 @@ loss_functions:
       coefficient: 5
   - stress_anisotropic:
       fn: mae
-      reduction: mean_all
+      reduction: mean
       coefficient: 5
 
 optim:

--- a/configs/omat24/mptrj/eqV2_31M_dens_mptrj.yml
+++ b/configs/omat24/mptrj/eqV2_31M_dens_mptrj.yml
@@ -54,7 +54,7 @@ loss_functions:
       coefficient: 5
   - stress_anisotropic:
       fn: mae
-      reduction: mean_all
+      reduction: mean
       coefficient: 5
 
 optim:

--- a/configs/omat24/mptrj/eqV2_31M_mptrj.yml
+++ b/configs/omat24/mptrj/eqV2_31M_mptrj.yml
@@ -54,7 +54,7 @@ loss_functions:
       coefficient: 5
   - stress_anisotropic:
       fn: mae
-      reduction: mean_all
+      reduction: mean
       coefficient: 5
 
 optim:

--- a/configs/omat24/mptrj/eqV2_86M_dens_mptrj.yml
+++ b/configs/omat24/mptrj/eqV2_86M_dens_mptrj.yml
@@ -54,7 +54,7 @@ loss_functions:
       coefficient: 5
   - stress_anisotropic:
       fn: mae
-      reduction: mean_all
+      reduction: mean
       coefficient: 5
 
 optim:


### PR DESCRIPTION
'mean_all' is no longer valid. 'mean' should be used now.