### PR TITLE
Modify runner and cli for state checkpointing

### DIFF
--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -184,9 +184,6 @@ class Submitit(Checkpointable):
         logging.info("Submitit checkpointing callback is completed")
         cfg_copy = self.config.copy()
         cfg_copy.job.runner_state_path = save_path
-        OmegaConf.save(
-            self.config, os.path.join(save_path, PREEMPTION_STATE_DIR_NAME + ".yaml")
-        )
         return DelayedSubmission(Submitit(), cfg_copy)
 
 

--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -79,6 +79,16 @@ class SchedulerConfig:
 
 
 @dataclass
+class Metadata:
+    # read-only metadata about the job, not user inputs
+    commit: str
+    log_dir: str
+    checkpoint_dir: str
+    config_path: str
+    preemption_checkpoint_dir: str
+
+
+@dataclass
 class JobConfig:
     run_name: str = field(
         default_factory=lambda: get_timestamp_uid() + uuid.uuid4().hex.upper()[0:4]
@@ -92,26 +102,24 @@ class JobConfig:
     seed: int = 0
     deterministic: bool = False
     runner_state_path: Optional[str] = None  # noqa: UP007
-    # read-only metadata about the job, not for user use
-    metadata: Optional[dict] = None  # noqa: UP007
+    # read-only metadata about the job, not user inputs
+    metadata: Optional[Metadata] = None  # noqa: UP007
 
     def __post_init__(self) -> None:
-        self.metadata = {
-            "commit": get_commit_hash(),
-            "log_dir": os.path.join(self.run_dir, self.timestamp_id, LOG_DIR_NAME),
-            "checkpoint_dir": os.path.join(
+        self.metadata = Metadata(
+            commit=get_commit_hash(),
+            log_dir=os.path.join(self.run_dir, self.timestamp_id, LOG_DIR_NAME),
+            checkpoint_dir=os.path.join(
                 self.run_dir, self.timestamp_id, CHECKPOINT_DIR_NAME
             ),
-            "config_path": os.path.join(
-                self.run_dir, self.timestamp_id, CONFIG_FILE_NAME
-            ),
-            "preemption_checkpoint_dir": os.path.join(
+            config_path=os.path.join(self.run_dir, self.timestamp_id, CONFIG_FILE_NAME),
+            preemption_checkpoint_dir=os.path.join(
                 self.run_dir,
                 self.timestamp_id,
                 CHECKPOINT_DIR_NAME,
                 PREEMPTION_STATE_DIR_NAME,
             ),
-        }
+        )
 
 
 def _set_seeds(seed: int) -> None:

--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -280,7 +280,7 @@ def main(
         )
         job = executor.submit(runner_wrapper, cfg)
         logging.info(
-            f"Submitted job id: {cfg.job.timestamp_id}, slurm id: {job.job_id}, logs: {cfg.job.log_dir}"
+            f"Submitted job id: {cfg.job.timestamp_id}, slurm id: {job.job_id}, logs: {cfg.job.metadata.log_dir}"
         )
     else:
         from torch.distributed.launcher.api import LaunchConfig, elastic_launch

--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -32,7 +32,11 @@ from submitit import AutoExecutor
 from submitit.helpers import Checkpointable, DelayedSubmission
 
 from fairchem.core.common import distutils
-from fairchem.core.common.utils import get_timestamp_uid, setup_env_vars
+from fairchem.core.common.utils import (
+    get_commit_hash,
+    get_timestamp_uid,
+    setup_env_vars,
+)
 
 # this effects the cli only since the actual job will be run in subprocesses or remoe
 logging.basicConfig(level=logging.INFO)
@@ -88,27 +92,26 @@ class JobConfig:
     seed: int = 0
     deterministic: bool = False
     runner_state_path: Optional[str] = None  # noqa: UP007
+    # read-only metadata about the job, not for user use
+    metadata: Optional[dict] = None  # noqa: UP007
 
-    @property
-    def log_dir(self) -> str:
-        return os.path.join(self.run_dir, self.timestamp_id, LOG_DIR_NAME)
-
-    @property
-    def checkpoint_dir(self) -> str:
-        return os.path.join(self.run_dir, self.timestamp_id, CHECKPOINT_DIR_NAME)
-
-    @property
-    def preemption_checkpoint_dir(self) -> str:
-        return os.path.join(
-            self.run_dir,
-            self.timestamp_id,
-            self.checkpoint_dir_name,
-            PREEMPTION_STATE_DIR_NAME,
-        )
-
-    @property
-    def config_path(self) -> str:
-        return os.path.join(self.run_dir, self.timestamp_id, CONFIG_FILE_NAME)
+    def __post_init__(self) -> None:
+        self.metadata = {
+            "commit": get_commit_hash(),
+            "log_dir": os.path.join(self.run_dir, self.timestamp_id, LOG_DIR_NAME),
+            "checkpoint_dir": os.path.join(
+                self.run_dir, self.timestamp_id, CHECKPOINT_DIR_NAME
+            ),
+            "config_path": os.path.join(
+                self.run_dir, self.timestamp_id, CONFIG_FILE_NAME
+            ),
+            "preemption_checkpoint_dir": os.path.join(
+                self.run_dir,
+                self.timestamp_id,
+                CHECKPOINT_DIR_NAME,
+                PREEMPTION_STATE_DIR_NAME,
+            ),
+        }
 
 
 def _set_seeds(seed: int) -> None:
@@ -130,53 +133,53 @@ def _set_deterministic_mode() -> None:
 class Submitit(Checkpointable):
     def __call__(self, dict_config: DictConfig) -> None:
         self.config = dict_config
-        self.job_config: JobConfig = OmegaConf.to_object(dict_config.job)
         # TODO also load job config here
         setup_env_vars()
-        distutils.setup(map_job_config_to_dist_config(self.job_config))
+        distutils.setup(map_job_config_to_dist_config(self.config.job))
         self._init_logger()
-        _set_seeds(self.job_config.seed)
-        if self.job_config.deterministic:
+        _set_seeds(self.config.job.seed)
+        if self.config.job.deterministic:
             _set_deterministic_mode()
 
         runner: Runner = hydra.utils.instantiate(dict_config.runner)
         runner.config = self.config
         # must call resume state AFTER the runner has been initialized
-        if self.job_config.runner_state_path:
-            runner.load_state(self.job_config.runner_state_path)
+        if self.config.job.runner_state_path:
+            runner.load_state(self.config.job.runner_state_path)
         runner.run()
         distutils.cleanup()
 
     def _init_logger(self) -> None:
         if (
-            self.job_config.logger
+            self.config.job.logger
             and distutils.is_master()
-            and not self.job_config.debug
+            and not self.config.job.debug
         ):
             # get a partial function from the config and instantiate wandb with it
             # currently this assume we use a wandb logger
-            logger_initializer = hydra.utils.instantiate(self.job_config.logger)
+            logger_initializer = hydra.utils.instantiate(self.config.job.logger)
             simple_config = OmegaConf.to_container(
                 self.config, resolve=True, throw_on_missing=True
             )
             logger_initializer(
                 config=simple_config,
-                run_id=self.job_config.timestamp_id,
-                run_name=self.job_config.run_name,
-                log_dir=self.job_config.log_dir,
+                run_id=self.config.job.timestamp_id,
+                run_name=self.config.job.run_name,
+                log_dir=self.config.job.metadata.log_dir,
             )
 
     def checkpoint(self, *args, **kwargs) -> DelayedSubmission:
         # TODO: this is yet to be tested properly
         logging.info("Submitit checkpointing callback is triggered")
-        new_runner = Submitit()
-        self.runner.save_state(self.job_config.preemption_checkpoint_dir)
+        save_path = self.config.job.metadata.preemption_checkpoint_dir
+        self.runner.save_state(save_path)
         logging.info("Submitit checkpointing callback is completed")
         cfg_copy = self.config.copy()
-        cfg_copy.job_config.runner_state_path = (
-            self.job_config.preemption_checkpoint_dir
+        cfg_copy.job.runner_state_path = save_path
+        OmegaConf.save(
+            self.config, os.path.join(save_path, PREEMPTION_STATE_DIR_NAME + ".yaml")
         )
-        return DelayedSubmission(new_runner, cfg_copy, self.cli_args)
+        return DelayedSubmission(Submitit(), cfg_copy)
 
 
 def map_job_config_to_dist_config(job_cfg: JobConfig) -> dict:
@@ -194,6 +197,10 @@ def map_job_config_to_dist_config(job_cfg: JobConfig) -> dict:
 
 
 def get_canonical_config(config: DictConfig) -> DictConfig:
+    # manually initialize metadata, because OmegaConf currently doesn't call __post_init__ on dataclasses
+    job = OmegaConf.to_object(config.job)
+    job.__post_init__()
+    config.job = job
     # check that each key other than the allowed top level keys are used in config
     # find all top level keys are not in the allowed set
     all_keys = set(config.keys()).difference(ALLOWED_TOP_LEVEL_KEYS)
@@ -248,20 +255,19 @@ def main(
     cfg = OmegaConf.merge({"job": OmegaConf.structured(JobConfig)}, cfg)
     # canonicalize config (remove top level keys that just used replacing variables)
     cfg = get_canonical_config(cfg)
-    job_obj = OmegaConf.to_object(cfg.job)
-    log_dir = job_obj.log_dir
-    os.makedirs(job_obj.run_dir, exist_ok=True)
+    log_dir = cfg.job.metadata.log_dir
+    os.makedirs(cfg.job.run_dir, exist_ok=True)
     os.makedirs(log_dir, exist_ok=True)
 
-    OmegaConf.save(cfg, job_obj.config_path)
-    logging.info(f"saved canonical config to {job_obj.config_path}")
+    OmegaConf.save(cfg, cfg.job.metadata.config_path)
+    logging.info(f"saved canonical config to {cfg.job.metadata.config_path}")
 
-    scheduler_cfg = job_obj.scheduler
+    scheduler_cfg = cfg.job.scheduler
     logging.info(f"Running fairchemv2 cli with {cfg}")
     if scheduler_cfg.mode == SchedulerType.SLURM:  # Run on cluster
         executor = AutoExecutor(folder=log_dir, slurm_max_num_timeout=3)
         executor.update_parameters(
-            name=job_obj.run_name,
+            name=cfg.job.run_name,
             mem_gb=scheduler_cfg.slurm.mem_gb,
             timeout_min=scheduler_cfg.slurm.timeout_hr * 60,
             slurm_partition=scheduler_cfg.slurm.partition,
@@ -274,7 +280,7 @@ def main(
         )
         job = executor.submit(runner_wrapper, cfg)
         logging.info(
-            f"Submitted job id: {job_obj.timestamp_id}, slurm id: {job.job_id}, logs: {job_obj.log_dir}"
+            f"Submitted job id: {cfg.job.timestamp_id}, slurm id: {job.job_id}, logs: {cfg.job.log_dir}"
         )
     else:
         from torch.distributed.launcher.api import LaunchConfig, elastic_launch

--- a/src/fairchem/core/components/runner.py
+++ b/src/fairchem/core/components/runner.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
-    from fairchem.core._cli_hydra import JobConfig
-
 
 class Runner(metaclass=ABCMeta):
     """
@@ -17,23 +15,23 @@ class Runner(metaclass=ABCMeta):
     """
 
     @property
-    def job_config(self) -> JobConfig:
-        return self._job_config
+    def config(self) -> DictConfig:
+        return self._config
 
-    @job_config.setter
-    def job_config(self, cfg: DictConfig):
-        self._job_config = cfg
+    @config.setter
+    def config(self, cfg: DictConfig):
+        self._config = cfg
 
     @abstractmethod
     def run(self) -> Any:
         raise NotImplementedError
 
     @abstractmethod
-    def save_state(self) -> None:
+    def save_state(self, checkpoint_location: str) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def load_state(self) -> None:
+    def load_state(self, checkpoint_location: str) -> None:
         raise NotImplementedError
 
 


### PR DESCRIPTION
- Add a runner.state field to Job which will be used for auto-preemptions and manual resume of training states.
- pass full config to Runner instead of the partial config so it can be saved
- Move the job paths to a metadata field instead of using properties, this avoids having to instantiate the job config everytime you want the properties

Note This is for preemptions and manual resumes for runners, the state should be agnostic of whats underneath the runner (ie: a trainer or something else).

TODO: right now the state loading doesn't reload config from the saved config, we should change to this so that its strict and independent of the given config?
<img width="473" alt="image" src="https://github.com/user-attachments/assets/abe01dc4-147f-4121-ab5b-6eed83088665" />
