### PR TITLE
Remove use of device from bbsampler

### DIFF
--- a/src/fairchem/core/common/data_parallel.py
+++ b/src/fairchem/core/common/data_parallel.py
@@ -126,7 +126,9 @@ class BalancedBatchSampler(BatchSampler):
         batch_size: int,
         num_replicas: int,
         rank: int,
-        device: torch.device,
+        device: (
+            torch.device | None
+        ) = None,  # deprecated, unused variable for backwards compat
         seed: int,
         mode: bool | Literal["atoms"] = "atoms",
         shuffle: bool = True,
@@ -191,7 +193,9 @@ class BalancedBatchSampler(BatchSampler):
         )
 
         super().__init__(sampler, batch_size=batch_size, drop_last=drop_last)
-        self.device = device
+        self.device = (
+            device if device is not None else distutils.get_device_for_local_rank()
+        )
 
         logging.info(
             f"Created BalancedBatchSampler with {sampler=}, {batch_size=}, {drop_last=}"

--- a/src/fairchem/core/common/distutils.py
+++ b/src/fairchem/core/common/distutils.py
@@ -242,7 +242,7 @@ def get_device_for_local_rank():
         return cur_dev_env
     else:
         device = "cuda" if torch.cuda.available() else "cpu"
-        logging.warn(
+        logging.warning(
             f"{CURRENT_DEVICE_STR} env variable not found, defaulting to {device}"
         )
         return device

--- a/src/fairchem/core/common/distutils.py
+++ b/src/fairchem/core/common/distutils.py
@@ -241,7 +241,7 @@ def get_device_for_local_rank():
     if cur_dev_env is not None:
         return cur_dev_env
     else:
-        device = "cuda" if torch.cuda.available() else "cpu"
+        device = "cuda" if torch.cuda.is_available() else "cpu"
         logging.warning(
             f"{CURRENT_DEVICE_STR} env variable not found, defaulting to {device}"
         )


### PR DESCRIPTION
BalancedBatchSampler needs a device as input, this is not useful as the device should be inferred, make this optional and backwards compatible