### PR TITLE
Update pyproject to match torch 2.4.x patch versions

### DIFF
--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -9,7 +9,7 @@ license = {text = "MIT License"}
 dynamic = ["version", "readme"]
 requires-python = ">=3.9, <3.13"
 dependencies = [
-    "torch==2.4",
+    "torch~=2.4.0",
     "numpy >=1.26.0, <2.0.0",
     "lmdb",
     "ase",


### PR DESCRIPTION
Our pyproject.toml is incompatible with our tested version (torch==2.4.1). This small patch simply makes it to pyproject.toml will match any 2.4.x patch release.

Alternatively, we could update pyproject.toml to pin to `torch==2.4.1`. 