### PR TITLE
sort fix for multiple src

### DIFF
--- a/src/fairchem/core/datasets/ase_datasets.py
+++ b/src/fairchem/core/datasets/ase_datasets.py
@@ -471,9 +471,11 @@ class AseDBDataset(AseAtomsDataset):
     def _load_dataset_get_ids(self, config: dict) -> list[int]:
         if isinstance(config["src"], list):
             filepaths = []
-            for path in config["src"]:
+            for path in sorted(config["src"]):
                 if os.path.isdir(path):
-                    filepaths.extend(glob(f"{path}/*"))
+                    filepaths.extend(
+                        sorted(glob(f"{path}/*"))
+                    )
                 elif os.path.isfile(path):
                     filepaths.append(path)
                 else:
@@ -481,13 +483,13 @@ class AseDBDataset(AseAtomsDataset):
         elif os.path.isfile(config["src"]):
             filepaths = [config["src"]]
         elif os.path.isdir(config["src"]):
-            filepaths = glob(f'{config["src"]}/*')
+            filepaths = sorted(glob(f'{config["src"]}/*'))
         else:
-            filepaths = glob(config["src"])
+            filepaths = sorted(glob(config["src"]))
 
         self.dbs = []
 
-        for path in sorted(filepaths):
+        for path in filepaths:
             try:
                 self.dbs.append(self.connect_db(path, config.get("connect_args", {})))
             except ValueError:

--- a/src/fairchem/core/datasets/ase_datasets.py
+++ b/src/fairchem/core/datasets/ase_datasets.py
@@ -473,9 +473,7 @@ class AseDBDataset(AseAtomsDataset):
             filepaths = []
             for path in sorted(config["src"]):
                 if os.path.isdir(path):
-                    filepaths.extend(
-                        sorted(glob(f"{path}/*"))
-                    )
+                    filepaths.extend(sorted(glob(f"{path}/*")))
                 elif os.path.isfile(path):
                     filepaths.append(path)
                 else:


### PR DESCRIPTION
There is a very subtle issue when your config contains dataset paths like this:

```
src = [
    "omat24/train/rattled-300",
    "omat24/train/rattled-300-subsampled"
]
```

The metadata in this case will first sort paths and then concatenate them, in this example - `rattled-300` and then `rattled-300-subsampled` - https://github.com/FAIR-Chem/fairchem/blob/1573d44f85b32a8156df8faa403244ddd6198eec/src/fairchem/core/datasets/base_dataset.py#L85-L91

However, when constructing the db ids it first combines all lmdbs across all paths: https://github.com/FAIR-Chem/fairchem/blob/1573d44f85b32a8156df8faa403244ddd6198eec/src/fairchem/core/datasets/ase_datasets.py#L473-L480

In the example above this is problematic since now the sorted order looks as follows:
```
omat24/train/rattled-300-subsampled/data.0000.aselmdb
omat24/train/rattled-300/data.0000.aselmdb
```

Which becomes inconsistent with the metadata ordering. For now we can patch this by sorted at the directory level and then concatenating them. A cleaner solution in the future should involved not relying on explicitly sorting in multiple locations but rather creating a global index that is used for all components.