### PR TITLE
Add disable_amp flag to OCP calculator

### DIFF
--- a/src/fairchem/core/common/relaxation/ase_utils.py
+++ b/src/fairchem/core/common/relaxation/ase_utils.py
@@ -124,7 +124,7 @@ class OCPCalculator(Calculator):
         cpu: bool = True,
         seed: int | None = None,
         only_output: list[str] | None = None,
-        disable_amp: bool = True
+        disable_amp: bool = True,
     ) -> None:
         """
         OCP-ASE Calculator

--- a/src/fairchem/core/common/relaxation/ase_utils.py
+++ b/src/fairchem/core/common/relaxation/ase_utils.py
@@ -125,6 +125,7 @@ class OCPCalculator(Calculator):
         cpu: bool = True,
         seed: int | None = None,
         only_output: list[str] | None = None,
+        disable_amp: bool = True
     ) -> None:
         """
         OCP-ASE Calculator
@@ -143,6 +144,13 @@ class OCPCalculator(Calculator):
                 OCP trainer to be used. "forces" for S2EF, "energy" for IS2RE.
             cpu (bool):
                 Whether to load and run the model on CPU. Set `False` for GPU.
+            seed (int):
+                Seed in the calculator to ensure reproducibility among instantiations
+            only_output (list):
+                A list of outputs to use from the model, rather than relying on the underlying task
+            disable_amp (bool):
+                Disable AMP in the calculator; AMP on is great for training, but often leads to headaches
+                during inference.
         """
         setup_imports()
         setup_logging()
@@ -251,6 +259,9 @@ class OCPCalculator(Calculator):
             )
         else:
             self.trainer.set_seed(seed)
+
+        if disable_amp:
+            self.trainer.scaler = None
 
         self.a2g = AtomsToGraphs(
             r_energy=False,

--- a/src/fairchem/core/common/relaxation/ase_utils.py
+++ b/src/fairchem/core/common/relaxation/ase_utils.py
@@ -169,6 +169,8 @@ class OCPCalculator(Calculator):
                 model_name=model_name, local_cache=local_cache
             )
 
+        checkpoint_path = Path(checkpoint_path)
+
         # Either the config path or the checkpoint path needs to be provided
         assert config_yml or checkpoint_path is not None
 

--- a/src/fairchem/core/common/relaxation/ase_utils.py
+++ b/src/fairchem/core/common/relaxation/ase_utils.py
@@ -37,8 +37,6 @@ from fairchem.core.models.model_registry import model_name_to_local_file
 from fairchem.core.preprocessing import AtomsToGraphs
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from torch_geometric.data import Batch
 
 

--- a/src/fairchem/core/common/relaxation/ase_utils.py
+++ b/src/fairchem/core/common/relaxation/ase_utils.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import copy
 import logging
+from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
Having AMP on often leads to trouble during inference (rounding errors, energies not changing during relaxations, etc). This PR adds a flag to the calculator to force it off, and also defaults that to True. This is done using the trainer.scaling=None trick, but we could also overwrite the config if that was cleaner

Users who know what they're doing can use disable_amp=False, but the default for new users who aren't aware of issues should be AMP off.