### PR TITLE
lower huggingfacehub version

### DIFF
--- a/packages/env.cpu.yml
+++ b/packages/env.cpu.yml
@@ -26,5 +26,5 @@ dependencies:
 - submitit
 - tensorboard
 - wandb
-- huggingface_hub
+- huggingface_hub>=0.27.1
 name: fair-chem

--- a/packages/env.gpu.yml
+++ b/packages/env.gpu.yml
@@ -29,5 +29,5 @@ dependencies:
 - submitit
 - tensorboard
 - wandb
-- huggingface_hub
+- huggingface_hub>=0.27.1
 name: fair-chem

--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "submitit",
     "hydra-core",
     "torchtnt",
-    "huggingface_hub>=0.2.1",
+    "huggingface_hub>=0.27.1",
     "pydantic>=2.10.0"
 ]
 

--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "submitit",
     "hydra-core",
     "torchtnt",
-    "huggingface_hub>=0.29.2",
+    "huggingface_hub>=0.2.1",
     "pydantic>=2.10.0"
 ]
 

--- a/packages/requirements.txt
+++ b/packages/requirements.txt
@@ -1,4 +1,4 @@
 torch==2.4.1
 numpy==1.26.4
 ase==3.24.0
-huggingface_hub==0.29.2
+huggingface_hub==0.27.1


### PR DESCRIPTION
Our repo currently conflicts with orb (causing a problem in quacc). Lowering the version minimum to huggingface_hub to the minimum tested version (0.27.1) that is compatible with cached-path.