### PR TITLE
Fix typo in model registry names

### DIFF
--- a/src/fairchem/core/models/pretrained_models.json
+++ b/src/fairchem/core/models/pretrained_models.json
@@ -287,7 +287,7 @@
         "repo_id": "fairchem/OMAT24",
         "filename": "eqV2_31M_omat.pt"
     },
-    "EquiformerV2-31M-OMAT24-mp-salex": {
+    "EquiformerV2-31M-OMAT24-MP-sAlex": {
         "type": "huggingface_hub",
         "repo_id": "fairchem/OMAT24",
         "filename": "eqV2_31M_omat_mp_salex.pt"


### PR DESCRIPTION
Fix a capitalization typo in the model registry names for OMAT potentials.