### PR TITLE
Remove runner_state_path from submission pickle

### DIFF
--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -242,6 +242,7 @@ class Submitit(Checkpointable):
         save_path = self.config.job.metadata.preemption_checkpoint_dir
         cfg_copy = self.config.copy()
         # only assign if the save was successful
+        cfg_copy.job.runner_state_path = None
         if self.runner.save_state(save_path, is_preemption=True):
             cfg_copy.job.runner_state_path = save_path
         if WandBSingletonLogger.initialized():

--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -230,7 +230,6 @@ class Submitit(Checkpointable):
         # self.runner.save_state(save_path)
         # For now, use the last found checkpoint
         cfg_copy = self.config.copy()
-        # cfg_copy.job.metadata.slurm_env.starting_from_preempted = True
         ckpt_dirs_time = get_subdirectories_sorted_by_time(
             self.config.job.metadata.checkpoint_dir
         )

--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -352,7 +352,6 @@ def main(
             slurm_account=scheduler_cfg.slurm.account,
         )
         job = executor.submit(Submitit(), cfg)
-        breakpoint()
         logging.info(
             f"Submitted job id: {cfg.job.timestamp_id}, slurm id: {job.job_id}, logs: {cfg.job.metadata.log_dir}"
         )

--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -223,8 +223,6 @@ class Submitit(Checkpointable):
 
     def checkpoint(self, *args, **kwargs) -> DelayedSubmission:
         logging.error("Submitit checkpointing callback is triggered")
-        # TODO: preemption state saving doesn't work with DCP because submitit only calls checkpoint
-        # on rank0, which will cause the system to deadlock.
         save_path = self.config.job.metadata.preemption_checkpoint_dir
         self.runner.save_state(save_path, is_preemption=True)
         cfg_copy = self.config.copy()

--- a/src/fairchem/core/common/utils.py
+++ b/src/fairchem/core/common/utils.py
@@ -1544,6 +1544,6 @@ def get_cluster_name() -> str:
         )
     except subprocess.CalledProcessError as e:
         logging.warning(
-            f"scontrol command failed, couldn't find cluster name, returning UNKOWN as cluster name {e!s}"
+            f"scontrol command failed, couldn't find cluster name, returning empty str as cluster name {e!s}"
         )
-        return "unknown"
+        return ""

--- a/src/fairchem/core/components/runner.py
+++ b/src/fairchem/core/components/runner.py
@@ -27,7 +27,7 @@ class Runner(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def save_state(self, checkpoint_location: str) -> None:
+    def save_state(self, checkpoint_location: str, is_preemption: bool = False) -> None:
         raise NotImplementedError
 
     @abstractmethod
@@ -47,7 +47,7 @@ class MockRunner(Runner):
             raise ValueError("sum is greater than 1000!")
         return self.x + self.y
 
-    def save_state(self, checkpoint_location: str) -> None:
+    def save_state(self, checkpoint_location: str, is_preemption: bool = False) -> None:
         pass
 
     def load_state(self, checkpoint_location: str | None) -> None:

--- a/src/fairchem/core/components/runner.py
+++ b/src/fairchem/core/components/runner.py
@@ -27,7 +27,7 @@ class Runner(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def save_state(self, checkpoint_location: str, is_preemption: bool = False) -> None:
+    def save_state(self, checkpoint_location: str, is_preemption: bool = False) -> bool:
         raise NotImplementedError
 
     @abstractmethod
@@ -47,7 +47,7 @@ class MockRunner(Runner):
             raise ValueError("sum is greater than 1000!")
         return self.x + self.y
 
-    def save_state(self, checkpoint_location: str, is_preemption: bool = False) -> None:
+    def save_state(self, checkpoint_location: str, is_preemption: bool = False) -> bool:
         pass
 
     def load_state(self, checkpoint_location: str | None) -> None:


### PR DESCRIPTION
In the event of node failures, submitit would re-queue the job with the same submitted pickle it started with. This is problematic if the original pickle contained runner_state (ie: path to runner checkpoint to resume), it would repeatedly resume from the same checkpoint because the state is captured in the pickle. 
-> Here we manually remove the state path (not the most elegant way unfortunately) so that the runner_state is not propagated to future restarts

Extra cleanup changes:
* Add `is_preemption` flag to `save_state`, this allows the jobs to distinguish between when the submitit preemption callback is triggered and normal state saving (which only runs on master rank so it must be treated differently)
* Add return flag for `save_state` to indicate whether the save attempt was successful
* Also Add few slurm metadata fields to track the job (job id and num restarts)

Testing:
- [x] manual resume - runner_state is populated, the slurm submission objects does not carry it for future runs 
- [x] preemptions - runner_state is populated, the slurm submission objects does not carry it for future runs 
- [x] requeue (node failure)  - no runner_state is populated
- [x] requeue  followed by preemption - this should start at the latest checkpoint (not using the preemption checkpoint)