### PR TITLE
Fix github codespace install

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [ -f packages/requirements.txt ]; then pip install -r packages/requirements.txt; fi
 if [ -f packages/requirements-optional.txt ]; then pip install -r packages/requirements-optional.txt; fi
-pip install -e packages/fairchem-core[dev]
+pip install -e packages/fairchem-core[dev,docs,adsorbml]
 pip install -e packages/fairchem-data-oc[dev]
 pip install -e packages/fairchem-demo-ocpapi[dev]
 pip install -e packages/fairchem-applications-cattsunami


### PR DESCRIPTION
The github codespace was missing the adsorbml requirements, including dscribe,x3dase,etc. This fixes that. 