### PR TITLE
Minor fix pkl downloads

### DIFF
--- a/src/fairchem/core/scripts/TEST.py
+++ b/src/fairchem/core/scripts/TEST.py
@@ -1,0 +1,12 @@
+import os
+import download_large_files
+from fairchem.data.oc.databases.pkls import BULK_PKL_PATH
+
+# Test calling the function and installing the bulk.pkl file; analogous
+# to init() in fairchem.data.oc.core.bulk 
+ 
+if not os.path.exists(BULK_PKL_PATH):
+    download_large_files.download_file_group("oc")
+else:
+    print(f"Path to bulk .pkl file already exists, under: {BULK_PKL_PATH}")
+

--- a/src/fairchem/core/scripts/download_large_files.py
+++ b/src/fairchem/core/scripts/download_large_files.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 from fairchem.core.common.tutorial_utils import fairchem_root
+from fairchem.data.oc.databases.pkls import BULK_PKL_PATH
 
 S3_ROOT = "https://dl.fbaipublicfiles.com/opencatalystproject/data/large_files/"
 
@@ -66,7 +67,11 @@ def download_file_group(file_group):
     fc_root = fairchem_root().parents[1]
     for file in files_to_download:
         if not (fc_root / file).exists():
-            print(f"Downloading {file}...")
+            print(f"BULK_PKL_PATH is: \t{BULK_PKL_PATH}")
+            print(f"fc_root / file is: \t{fc_root / file}")
+            print(f"fc_root is: \t\t{fc_root}")
+            print(f"file is: \t\t{file}\n")
+            # print(f"Downloading {file}...")
             urlretrieve(S3_ROOT + file.name, fc_root / file)
         else:
             print(f"{file} already exists")


### PR DESCRIPTION
When `download_file_group()` from `fairchem.core.scripts` is called and finds file(s) to download into directory within a local fairchem installation it will assume that the overall path will have the same absolute structure as the repository which is not true in case of using anaconda to manage the fairchem installation for example.

When calling `urlretrieve(S3_ROOT + file.name, fc_root / file)`, `S3_ROOT + file.name` is still correct because file.name only contains the single name of the file that has to be downloaded. Yet joining `fc_root` and `file` seems to be the main issue here:


```
$ python TEST.py 
BULK_PKL_PATH is:       C:\Users\user\anaconda3\envs\fair-chem\Lib\site-packages\fairchem\data\oc\databases\pkls\bulks.pkl
fc_root / file is:      C:\Users\user\anaconda3\envs\fair-chem\Lib\src\fairchem\data\oc\databases\pkls\bulks.pkl
fc_root is:             C:\Users\user\anaconda3\envs\fair-chem\Lib
file is:                src\fairchem\data\oc\databases\pkls\bulks.pkl

Traceback (most recent call last):
  File "C:\Users\user\...\forked-repos\fairchem\src\fairchem\core\scripts\TEST.py", line 9, in <module>
    download_large_files.download_file_group("oc")
  File "C:\Users\user\...\forked-repos\fairchem\src\fairchem\core\scripts\download_large_files.py", line 75, in download_file_group
    urlretrieve(S3_ROOT + file.name, fc_root / file)
  File "C:\Users\user\anaconda3\envs\fair-chem\Lib\urllib\request.py", line 250, in urlretrieve
    tfp = open(filename, 'wb')
          ^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\user\\anaconda3\\envs\\fair-chem\\Lib\\src\\fairchem\\data\\oc\\databases\\pkls\\bulks.pkl'
```

So really, all that is missing is `src` should be replaced by `site-packages`; `BULK_PKL_PATH `has the right path to our pkl files, perhaps we can just replace `fc_root / file` with `BULK_PKL_PATH`  in line 69 of `download_file_group()`?

Looking forward to any feedback! Test script for this output is inside `fairchem.core.scripts`. I am aware that TEST.py imports the locally modified download_large_files.py while simultaneously using my conda env mixing up things - the bug is still there however, let me know if there is a smarter way for me to use only the locally installed fork of fairchem (_not_ the conda env with fairchem) so I can be more consistent :)