### PR TITLE
Minor fixes in tutorial notebook regarding directory naming and one typo

### DIFF
--- a/src/fairchem/applications/AdsorbML/tutorials/adsorbml_walkthrough.ipynb
+++ b/src/fairchem/applications/AdsorbML/tutorials/adsorbml_walkthrough.ipynb
@@ -2,12 +2,12 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "cee85286-fcfe-452b-9017-7c0bce8168bf",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from faichem.core.common.relaxation.ase_utils import OCPCalculator\n",
+    "from fairchem.core.common.relaxation.ase_utils import OCPCalculator\n",
     "import ase.io\n",
     "from ase.optimize import BFGS\n",
     "\n",
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "fe297959-7de2-4e54-bca6-562b230de12c",
    "metadata": {},
    "outputs": [
@@ -298,16 +298,22 @@
    ],
    "source": [
     "checkpoint_path = \"your-path-here.pt\"\n",
-    "os.makedirs(f\"data/{bulk}_{adsorbate}\", exist_ok=True)\n",
+    "\n",
+    "# Store formulas of bulk and adsorbate as strings for creating corresponding directory\n",
+    "bulk_name = str(bulk.atoms.symbols)\n",
+    "adsorbate_name = str(adsorbate.atoms.symbols)\n",
+    "\n",
+    "os.makedirs(f\"data/{bulk_name}_{adsorbate_name}\", exist_ok=True)\n",
     "\n",
     "# Define the calculator\n",
     "calc = OCPCalculator(checkpoint_path=checkpoint_path, cpu = False) # if you dont have a gpu, change to `cpu=True` to run on cpu\n",
     "\n",
     "adslabs = [*heuristic_adslabs.atoms_list, *random_adslabs.atoms_list]\n",
+    "\n",
     "# Set up the calculator\n",
     "for idx, adslab in enumerate(adslabs):\n",
     "    adslab.calc = calc\n",
-    "    opt = BFGS(adslab, trajectory=f\"data/{bulk}_{adsorbate}/{idx}.traj\")\n",
+    "    opt = BFGS(adslab, trajectory=f\"data/{bulk_name}_{adsorbate_name}/{idx}.traj\")\n",
     "    opt.run(fmax=0.05, steps=100) # For the AdsorbML results we used fmax = 0.02 and steps = 300, but we will use less strict values for brevity."
    ]
   },
@@ -329,14 +335,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "0d005711-c702-4362-b930-f5bb8a6bbc55",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Iterate over trajs to extract results\n",
     "results = []\n",
-    "for file in glob(f\"data/{bulk}_{adsorbate}/*.traj\"):\n",
+    "for file in glob(f\"data/{bulk_name}_{adsorbate_name}/*.traj\"):\n",
     "    rx_id = file.split(\"/\")[-1].split(\".\")[0]\n",
     "    traj = ase.io.read(file, \":\")\n",
     "    \n",


### PR DESCRIPTION
Previously, the Bulk and Adsorbate objects where passed directly when calling `os.makedir()`, which lead to errors with illegal characters. This proposes extracting the formulas and storing them as strings, then combining the strings when creating the directory where the trajectories from the `OCPCalculator `land.

Also the first import had a typo, missing an 'r'.