### PR TITLE
Fix tensorboard logger

### DIFF
--- a/src/fairchem/core/trainers/base_trainer.py
+++ b/src/fairchem/core/trainers/base_trainer.py
@@ -936,7 +936,10 @@ class BaseTrainer(ABC):
         if self.scaler:
             self.scaler.unscale_(self.optimizer)
             # log unscaled weights and grads
-            log_weight_frequency = self.config["logger"].get("log_weight_table", -1)
+            if isinstance(self.config["logger"], dict):
+                log_weight_frequency = self.config["logger"].get("log_weight_table", -1)
+            else:
+                log_weight_frequency = -1  # not wandb
             if (
                 self.logger is not None
                 and distutils.is_master()


### PR DESCRIPTION
When the logger is tensorboard, `self.config["logger"]` would be `str` instead of `dict`. This would cause:

```
[rank0]:   File "fairchem/src/fairchem/core/trainers/base_trainer.py", line 939, in _backward
[rank0]:     log_weight_frequency = self.config["logger"].get("log_weight_table", -1)
[rank0]:                            ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: AttributeError: 'str' object has no attribute 'get'
```