### PR TITLE
Config descriptors

### DIFF
--- a/src/fairchem/core/_cli_hydra.py
+++ b/src/fairchem/core/_cli_hydra.py
@@ -244,13 +244,14 @@ class Submitit(Checkpointable):
 
         if run_type == RunType.RUN:
             self.runner: Runner = hydra.utils.instantiate(self.config.runner)
-            self.runner.initialize(self.config.job)
+            self.runner.job_config = self.config.job
             # must call resume state AFTER the runner has been initialized
             self.runner.load_state(self.config.job.runner_state_path)
             self.runner.run()
         elif run_type == RunType.REDUCE:
             self.reducer: Reducer = hydra.utils.instantiate(self.config.reducer)
-            self.reducer.initialize(self.config.job, self.config.runner)
+            self.reducer.job_config = self.config.job
+            self.reducer.runner_config = self.config.runner
             # must call resume state AFTER the runner has been initialized
             self.reducer.load_state(self.config.job.runner_state_path)
             self.reducer.reduce()

--- a/src/fairchem/core/components/reducer.py
+++ b/src/fairchem/core/components/reducer.py
@@ -8,11 +8,14 @@ LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from omegaconf import DictConfig
 
 from fairchem.core.components.utils import ManagedAttribute
+
+if TYPE_CHECKING:
+    from fairchem.core.components.runner import Runner
 
 
 class Reducer(metaclass=ABCMeta):
@@ -22,6 +25,12 @@ class Reducer(metaclass=ABCMeta):
 
     job_config = ManagedAttribute(enforced_type=DictConfig)
     runner_config = ManagedAttribute(enforced_type=DictConfig)
+
+    @property
+    @abstractmethod
+    def runner_type(self) -> Runner:
+        """The runner type this reducer is associated with."""
+        raise NotImplementedError
 
     @abstractmethod
     def reduce(self) -> Any:
@@ -39,6 +48,12 @@ class Reducer(metaclass=ABCMeta):
 
 class MockReducer(Reducer):
     """Used for testing"""
+
+    @property
+    def runner_type(self):
+        from fairchem.core.components.runner import MockRunner
+
+        return MockRunner
 
     def reduce(self) -> Any:
         runner_path = self.runner_config.pop("_target_")

--- a/src/fairchem/core/components/reducer.py
+++ b/src/fairchem/core/components/reducer.py
@@ -19,8 +19,15 @@ if TYPE_CHECKING:
 
 
 class Reducer(metaclass=ABCMeta):
-    """
-    Represents an abstraction over things that reduce the results written by a set of runner.
+    """Represents an abstraction over things that reduce the results written by a set of runner.
+
+    Note:
+        When running with the `fairchemv2` cli, the `job_config` and `runner_config` attributes are set at
+        runtime to those given in the config file.
+
+    Attributes:
+        job_config (DictConfig): a managed attribute that gives access to the job config
+        runner_config (DictConfig): a managed attributed that gives access to the calling runner config
     """
 
     job_config = ManagedAttribute(enforced_type=DictConfig)

--- a/src/fairchem/core/components/reducer.py
+++ b/src/fairchem/core/components/reducer.py
@@ -8,12 +8,11 @@ LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from fairchem.core.components.utils import DictConfigAccess
+from omegaconf import DictConfig
 
-if TYPE_CHECKING:
-    from omegaconf import DictConfig
+from fairchem.core.components.utils import ManagedAttribute
 
 
 class Reducer(metaclass=ABCMeta):
@@ -21,8 +20,8 @@ class Reducer(metaclass=ABCMeta):
     Represents an abstraction over things that reduce the results written by a set of runner.
     """
 
-    job_config = DictConfigAccess()
-    runner_config = DictConfigAccess()
+    job_config = ManagedAttribute(enforced_type=DictConfig)
+    runner_config = ManagedAttribute(enforced_type=DictConfig)
 
     @abstractmethod
     def reduce(self) -> Any:

--- a/src/fairchem/core/components/reducer.py
+++ b/src/fairchem/core/components/reducer.py
@@ -28,7 +28,7 @@ class Reducer(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def runner_type(self) -> Runner:
+    def runner_type(self) -> type[Runner]:
         """The runner type this reducer is associated with."""
         raise NotImplementedError
 

--- a/src/fairchem/core/components/reducer.py
+++ b/src/fairchem/core/components/reducer.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 class Reducer(metaclass=ABCMeta):
     """
-    Represents an abstraction over things reduce the results written by a runner.
+    Represents an abstraction over things that reduce the results written by a set of runner.
     """
 
     job_config = DictConfigAccess()

--- a/src/fairchem/core/components/reducer.py
+++ b/src/fairchem/core/components/reducer.py
@@ -40,18 +40,11 @@ class Reducer(metaclass=ABCMeta):
 class MockReducer(Reducer):
     """Used for testing"""
 
-    def __init__(self):
-        self.calling_runner_config = None
-
-    def initialize(self, job_config: DictConfig, runner_config: DictConfig) -> None:
-        """Initialize takes both the job config and a runner config assumed to have been run beforehand"""
-        self.calling_runner_config = runner_config
-
     def reduce(self) -> Any:
-        runner_path = self.calling_runner_config.pop("_target_")
+        runner_path = self.runner_config.pop("_target_")
         print(
             f"Reducing results from runner {runner_path} with args: "
-            f"{', '.join(f'{k}: {v}' for k, v in self.calling_runner_config.items())}"
+            f"{', '.join(f'{k}: {v}' for k, v in self.runner_config.items())}"
         )
 
     def save_state(self, checkpoint_location: str, is_preemption: bool = False) -> bool:

--- a/src/fairchem/core/components/reducer.py
+++ b/src/fairchem/core/components/reducer.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any
 
+from fairchem.core.components.utils import DictConfigAccess
+
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
@@ -19,10 +21,8 @@ class Reducer(metaclass=ABCMeta):
     Represents an abstraction over things reduce the results written by a runner.
     """
 
-    @abstractmethod
-    def initialize(self, job_config: DictConfig, runner_config: DictConfig) -> None:
-        """Initialize takes both the job config and a runner config assumed to have been run beforehand"""
-        raise NotImplementedError
+    job_config = DictConfigAccess()
+    runner_config = DictConfigAccess()
 
     @abstractmethod
     def reduce(self) -> Any:

--- a/src/fairchem/core/components/runner.py
+++ b/src/fairchem/core/components/runner.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any
 
+from fairchem.core.components.utils import DictConfigAccess
+
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
@@ -21,9 +23,7 @@ class Runner(metaclass=ABCMeta):
     This allows us to decouple away from a monolithic trainer class
     """
 
-    @abstractmethod
-    def initialize(self, job_config: DictConfig) -> None:
-        raise NotImplementedError
+    job_config = DictConfigAccess()
 
     @abstractmethod
     def run(self) -> Any:

--- a/src/fairchem/core/components/runner.py
+++ b/src/fairchem/core/components/runner.py
@@ -16,10 +16,16 @@ from fairchem.core.components.utils import ManagedAttribute
 
 
 class Runner(metaclass=ABCMeta):
-    """
-    Represents an abstraction over things that run in a loop and can save/load state.
+    """Represents an abstraction over things that run in a loop and can save/load state.
+
     ie: Trainers, Validators, Relaxation all fall in this category.
-    This allows us to decouple away from a monolithic trainer class
+
+    Note:
+        When running with the `fairchemv2` cli, the `job_config` and attribute is set at
+        runtime to those given in the config file.
+
+    Attributes:
+        job_config (DictConfig): a managed attribute that gives access to the job config
     """
 
     job_config = ManagedAttribute(enforced_type=DictConfig)

--- a/src/fairchem/core/components/runner.py
+++ b/src/fairchem/core/components/runner.py
@@ -50,9 +50,6 @@ class MockRunner(Runner):
             raise ValueError("sum is greater than 1000!")
         return self.x + self.y
 
-    def initialize(self, job_config: DictConfig) -> None:
-        pass
-
     def save_state(self, checkpoint_location: str, is_preemption: bool = False) -> bool:
         pass
 

--- a/src/fairchem/core/components/runner.py
+++ b/src/fairchem/core/components/runner.py
@@ -8,12 +8,11 @@ LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from fairchem.core.components.utils import DictConfigAccess
+from omegaconf import DictConfig
 
-if TYPE_CHECKING:
-    from omegaconf import DictConfig
+from fairchem.core.components.utils import ManagedAttribute
 
 
 class Runner(metaclass=ABCMeta):
@@ -23,7 +22,7 @@ class Runner(metaclass=ABCMeta):
     This allows us to decouple away from a monolithic trainer class
     """
 
-    job_config = DictConfigAccess()
+    job_config = ManagedAttribute(enforced_type=DictConfig)
 
     @abstractmethod
     def run(self) -> Any:

--- a/src/fairchem/core/components/utils.py
+++ b/src/fairchem/core/components/utils.py
@@ -1,0 +1,36 @@
+"""
+Copyright (c) Meta, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from omegaconf import DictConfig
+
+if TYPE_CHECKING:
+    from fairchem.core.components.reducer import Reducer
+    from fairchem.core.components.runner import Runner
+
+
+class DictConfigAccess:
+    """A descriptor helper to manage setting/access to a DictConfig attribute of a class"""
+
+    def __set_name__(self, owner: Runner | Reducer, name: str):
+        self.public_name: str = name
+        self.private_name: str = "_" + name
+
+    def __get__(
+        self, obj: Runner | Reducer, objtype: type[Runner | Reducer] | None = None
+    ):
+        return getattr(obj, self.private_name)
+
+    def __set__(self, obj: Runner | Reducer, value: DictConfig):
+        if not isinstance(value, DictConfig):
+            raise ValueError(
+                f"{self.public_name} can only be set to an instance of {type(DictConfig)} type!"
+            )
+        setattr(obj, self.private_name, value)

--- a/src/fairchem/core/components/utils.py
+++ b/src/fairchem/core/components/utils.py
@@ -7,17 +7,18 @@ LICENSE file in the root directory of this source tree.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from omegaconf import DictConfig
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from fairchem.core.components.reducer import Reducer
     from fairchem.core.components.runner import Runner
 
 
-class DictConfigAccess:
-    """A descriptor helper to manage setting/access to a DictConfig attribute of a class"""
+class ManagedAttribute:
+    """A descriptor helper to manage setting/access to an attribute of a class"""
+
+    def __init__(self, enforced_type: type | None = None):
+        self._enforced_type = enforced_type
 
     def __set_name__(self, owner: Runner | Reducer, name: str):
         self.public_name: str = name
@@ -28,9 +29,11 @@ class DictConfigAccess:
     ):
         return getattr(obj, self.private_name)
 
-    def __set__(self, obj: Runner | Reducer, value: DictConfig):
-        if not isinstance(value, DictConfig):
+    def __set__(self, obj: Runner | Reducer, value: Any):
+        if self._enforced_type is not None and not isinstance(
+            value, self._enforced_type
+        ):
             raise ValueError(
-                f"{self.public_name} can only be set to an instance of {type(DictConfig)} type!"
+                f"{self.public_name} can only be set to an instance of {self._enforced_type} type!"
             )
         setattr(obj, self.private_name, value)


### PR DESCRIPTION
Add a `ManagedAttribute` descriptor as a formal way to write interfaces and allow runners to access a job config and reducers to access a job config and the calling runner config

* remove `initialize` method and use direct assignment with the  `ManagedAttribute`  descriptor