### PR TITLE
Log test duration, disable ESCN compiles tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           pip install -e packages/fairchem-data-oc[dev]
           pip install -e packages/fairchem-demo-ocpapi[dev]
           pip install -e packages/fairchem-applications-cattsunami
-      
+
       - name: Install core dependencies and package
         if: ${{ !matrix.pip_develop}}
         run: |
@@ -69,7 +69,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN_OMAT_READONLY }}
         run: |
-          pytest tests -vv --ignore=tests/demo/ocpapi/tests/integration/  --cov-report=xml --cov=fairchem -c ./packages/fairchem-core/pyproject.toml
+          pytest tests --durations=0 -vv --ignore=tests/demo/ocpapi/tests/integration/  --cov-report=xml --cov=fairchem -c ./packages/fairchem-core/pyproject.toml
 
       - if: ${{ matrix.python_version == '3.12' }}
         name: codecov-report

--- a/tests/core/models/test_escn_compiles.py
+++ b/tests/core/models/test_escn_compiles.py
@@ -151,6 +151,9 @@ def check_escn_equivalent(data, model1, model2):
     assert torch.allclose(output2["forces"], output2["forces"])
 
 
+@pytest.mark.skip(
+    reason="These tests are temporarily disabled as their runtimes shot up and can flake"
+)
 class TestESCNCompiles:
     def test_escn_baseline_cpu(self):
         init("gloo")


### PR DESCRIPTION
- Add arg to log all test durations
- Disable escn compiles tests as they have suddenly dramatically increased in duration
