### PR TITLE
add eSEN model checkpoints to registry

### DIFF
--- a/src/fairchem/core/models/model_registry.py
+++ b/src/fairchem/core/models/model_registry.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 class HuggingFaceModel(BaseModel):
     type: Literal["huggingface_hub"]
-    repo_id: Literal["fairchem/OMAT24"]
+    repo_id: Literal["facebook/OMAT24"]
     filename: str
 
 

--- a/src/fairchem/core/models/pretrained_models.json
+++ b/src/fairchem/core/models/pretrained_models.json
@@ -269,52 +269,67 @@
     },
     "EquiformerV2-153M-OMAT24": {
         "type": "huggingface_hub",
-        "repo_id": "fairchem/OMAT24",
+        "repo_id": "facebook/OMAT24",
         "filename": "eqV2_153M_omat.pt"
     },
     "EquiformerV2-153M-OMAT24-MP-sAlex": {
         "type": "huggingface_hub",
-        "repo_id": "fairchem/OMAT24",
+        "repo_id": "facebook/OMAT24",
         "filename": "eqV2_153M_omat_mp_salex.pt"
     },
     "EquiformerV2-31M-MP": {
         "type": "huggingface_hub",
-        "repo_id": "fairchem/OMAT24",
+        "repo_id": "facebook/OMAT24",
         "filename": "eqV2_31M_mp.pt"
     },
     "EquiformerV2-31M-OMAT24": {
         "type": "huggingface_hub",
-        "repo_id": "fairchem/OMAT24",
+        "repo_id": "facebook/OMAT24",
         "filename": "eqV2_31M_omat.pt"
     },
     "EquiformerV2-31M-OMAT24-MP-sAlex": {
         "type": "huggingface_hub",
-        "repo_id": "fairchem/OMAT24",
+        "repo_id": "facebook/OMAT24",
         "filename": "eqV2_31M_omat_mp_salex.pt"
     },
     "EquiformerV2-86M-OMAT24": {
         "type": "huggingface_hub",
-        "repo_id": "fairchem/OMAT24",
+        "repo_id": "facebook/OMAT24",
         "filename": "eqV2_86M_omat.pt"
     },
     "EquiformerV2-86M-OMAT24-MP-sAlex": {
         "type": "huggingface_hub",
-        "repo_id": "fairchem/OMAT24",
+        "repo_id": "facebook/OMAT24",
         "filename": "eqV2_86M_omat_mp_salex.pt"
     },
     "EquiformerV2-DeNS-153M-MP": {
         "type": "huggingface_hub",
-        "repo_id": "fairchem/OMAT24",
+        "repo_id": "facebook/OMAT24",
         "filename": "eqV2_dens_153M_mp.pt"
     },
     "EquiformerV2-DeNS-86M-MP": {
         "type": "huggingface_hub",
-        "repo_id": "fairchem/OMAT24",
+        "repo_id": "facebook/OMAT24",
         "filename": "eqV2_dens_86M_mp.pt"
     },
     "EquiformerV2-DeNS-31M-MP": {
         "type": "huggingface_hub",
-        "repo_id": "fairchem/OMAT24",
+        "repo_id": "facebook/OMAT24",
         "filename": "eqV2_dens_31M_mp.pt"
+    },
+    "eSEN-30M-OMAT24": {
+        "type": "huggingface_hub",
+        "repo_id": "facebook/OMAT24",
+        "filename": "esen_30m_omat.pt"
+    },
+    "eSEN-30M-OAM": {
+        "type": "huggingface_hub",
+        "repo_id": "facebook/OMAT24",
+        "filename": "esen_30m_oam.pt"
+    },
+    "eSEN-30M-MP": {
+        "type": "huggingface_hub",
+        "repo_id": "facebook/OMAT24",
+        "filename": "esen_30m_mptrj.pt"
     }
 }


### PR DESCRIPTION
Added eSEN-30M checkpoints that can be downloaded from hugging face, i.e.

```python
from fairchem.core import OCPCalculator

calc = OCPCalculator(model_name="eSEN-30M-OAM", cache_dir=".cache")
```